### PR TITLE
fix the return values for 'list' command, allows output to be transfo…

### DIFF
--- a/src/acrcssc/azext_acrcssc/cssc.py
+++ b/src/acrcssc/azext_acrcssc/cssc.py
@@ -139,7 +139,6 @@ def list_scan_status(cmd, registry_name, resource_group_name, status, workflow_t
     registry = acr_client_registries.get(resource_group_name, registry_name)
 
     image_status = track_scan_progress(cmd, resource_group_name, registry, status)
-    for image in image_status:
-        print(image)
-
     print(f"Total images: {len(image_status)}")
+
+    return image_status


### PR DESCRIPTION
This pull request includes several changes aimed at improving the handling and representation of scan and workflow statuses in the `azext_acrcssc` module. The most important changes include modifying the return values of functions to be more structured, and refactoring the string representation of workflow statuses.

### Improvements to status handling and representation:

* [`src/acrcssc/azext_acrcssc/cssc.py`](diffhunk://#diff-7839ffe03905f898dd02d473b3c6682cbf8463d562501070430f0c687fffc3fdL142-R144): Modified the `list_scan_status` function to return the `image_status` list instead of just printing each image.

* [`src/acrcssc/azext_acrcssc/helper/_workflow_status.py`](diffhunk://#diff-26500f39cbb90090aa6cbfd3ee1b2e94454ea79085dfc9e76760e62f944f4c3bL257-R260): Updated the `from_taskrun` function to return a list of status dictionaries instead of `WorkflowTaskStatus` objects.

### Refactoring for better structure:

* [`src/acrcssc/azext_acrcssc/helper/_workflow_status.py`](diffhunk://#diff-26500f39cbb90090aa6cbfd3ee1b2e94454ea79085dfc9e76760e62f944f4c3bL277-R310): Refactored the `__str__` method to use a dictionary for constructing the status representation, and added a `get_status` method to facilitate this change.