### PR TITLE
fix(cssc): 30943055 add a 'canceled' state for scan and patching workflows

### DIFF
--- a/src/acrcssc/azext_acrcssc/helper/_taskoperations.py
+++ b/src/acrcssc/azext_acrcssc/helper/_taskoperations.py
@@ -264,7 +264,7 @@ def _retrieve_logs_for_image(cmd, registry, resource_group_name, schedule, workf
 
     image_status = WorkflowTaskStatus.from_taskrun(cmd, acr_task_run_client, registry, scan_taskruns, patch_taskruns, progress_indicator=progress_indicator)
     if workflow_status:
-        filtered_image_status = [image for image in image_status if image.status() == workflow_status]
+        filtered_image_status = [image for image in image_status if image["patch_status"] == workflow_status or image["scan_status"] == workflow_status]
         image_status = filtered_image_status
 
     end_time = time.time()

--- a/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
@@ -31,6 +31,7 @@ class WorkflowTaskState(Enum):
     FAILED = "Failed"
     QUEUED = "Queued"
     SKIPPED = "Skipped"
+    CANCELED = "Canceled"
     UNKNOWN = "Unknown"
 
 
@@ -79,7 +80,10 @@ class WorkflowTaskStatus:
         if status == TaskRunStatus.Queued.value.lower():
             return WorkflowTaskState.QUEUED.value
 
-        if status == TaskRunStatus.Failed.value.lower() or status == TaskRunStatus.Canceled.value.lower() or status == TaskRunStatus.Error.value.lower() or status == TaskRunStatus.Timeout.value.lower():
+        if status == TaskRunStatus.Canceled.value.lower():
+            return WorkflowTaskState.CANCELED.value
+
+        if status == TaskRunStatus.Failed.value.lower() or status == TaskRunStatus.Error.value.lower() or status == TaskRunStatus.Timeout.value.lower():
             return WorkflowTaskState.FAILED.value
 
         return WorkflowTaskState.UNKNOWN.value
@@ -92,8 +96,10 @@ class WorkflowTaskStatus:
             return [TaskRunStatus.Running.value, TaskRunStatus.Started.value]
         if status == WorkflowTaskState.QUEUED.value:
             return [TaskRunStatus.Queued.value]
+        if status == WorkflowTaskState.CANCELED.value:
+            return [TaskRunStatus.Canceled.value]
         if status == WorkflowTaskState.FAILED.value:
-            return [TaskRunStatus.Failed.value, TaskRunStatus.Canceled.value, TaskRunStatus.Error.value, TaskRunStatus.Timeout.value]
+            return [TaskRunStatus.Failed.value, TaskRunStatus.Error.value, TaskRunStatus.Timeout.value]
         return None
 
     def scan_status(self):

--- a/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
@@ -254,7 +254,6 @@ class WorkflowTaskStatus:
                 patch_task = next(task for task in patch_taskruns if task.run_id == patch_task_id)
                 all_status[image].patch_task = patch_task
 
-        # don't return a list of WorkflowTaskStatus object, 
         return [status.get_status() for status in all_status.values()]
 
     def get_status(self):

--- a/src/acrcssc/setup.py
+++ b/src/acrcssc/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '1.1.1rc5'
+VERSION = '1.1.1rc7'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
'Canceled' state was originally mapped as part of the 'Failed' state in the `WorkflowTaskState` enum.
This change makes the 'Canceled' state so it maps to ACR Task's state.
Since this is part of the enum, the help text and the `--run-status` option does not require additional changes

```
az acr supply-chain workflow list ... --run-status canceled
Total images: 5
[
  {
    "image": "import:dotnetapp-manual",
    "last_patched_image": "import:dotnetapp-manual-1",
    "patch_date": "---Not Available---",
    "patch_status": "Unknown",
    "patch_task_ID": "---Not Available---",
    "scan_date": "2025-01-23T22:36:54.223026+00:00",
    "scan_status": "Canceled",
    "scan_task_ID": "dt23q",
    "workflow_type": "continuouspatchv1"
  },
...
```

```
$  az acr supply-chain workflow list  -h
...
    --run-status                   : Status to filter the supply-chain workflow image status.
                                     Allowed values: Canceled, Failed, Queued, Running, Skipped,
                                     Succeeded, Unknown.
```