### PR TITLE
fix(cssc): 31038071 Rename "skipped_patch_reason" to "patch_skipped_reason" to bring all patching props together

### DIFF
--- a/src/acrcssc/azext_acrcssc/helper/_taskoperations.py
+++ b/src/acrcssc/azext_acrcssc/helper/_taskoperations.py
@@ -264,7 +264,7 @@ def _retrieve_logs_for_image(cmd, registry, resource_group_name, schedule, workf
 
     image_status = WorkflowTaskStatus.from_taskrun(cmd, acr_task_run_client, registry, scan_taskruns, patch_taskruns, progress_indicator=progress_indicator)
     if workflow_status:
-        filtered_image_status = [image for image in image_status if image.status() == workflow_status]
+        filtered_image_status = [image for image in image_status if image["patch_status"] == workflow_status or image["scan_status"] == workflow_status]
         image_status = filtered_image_status
 
     end_time = time.time()

--- a/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
@@ -163,7 +163,7 @@ class WorkflowTaskStatus:
             return repository, patched_tag, original_tag
         return None
 
-    def _get_skip_patch_reason_from_tasklog(self):
+    def _get_patch_skip_reason_from_tasklog(self):
         if self.scan_task is None:
             return None
         match = re.search(r'PATCHING will be skipped as (.+)\n', self.scan_logs)
@@ -265,11 +265,11 @@ class WorkflowTaskStatus:
         patch_task_id = WORKFLOW_STATUS_NOT_AVAILABLE if self.patch_task is None else self.patch_task.run_id
         patched_image = self._get_patched_image_name_from_tasklog()
         workflow_type = CSSCTaskTypes.ContinuousPatchV1.value
-        skipped_patch_reason = ""
+        patch_skipped_reason = ""
 
         # this situation means that we don't have a patched image
         if self.patch_status() == WorkflowTaskState.SKIPPED.value:
-            skipped_patch_reason = self._get_skip_patch_reason_from_tasklog()
+            patch_skipped_reason = self._get_patch_skip_reason_from_tasklog()
 
         if patched_image == self.image():
             patched_image = WORKFLOW_STATUS_PATCH_NOT_AVAILABLE
@@ -282,8 +282,8 @@ class WorkflowTaskStatus:
             "patch_status": patch_status
         }
 
-        if skipped_patch_reason != "":
-            result["skipped_patch_reason"] = skipped_patch_reason
+        if patch_skipped_reason != "":
+            result["patch_skipped_reason"] = patch_skipped_reason
 
         result["patch_date"] = patch_date
         result["patch_task_ID"] = patch_task_id
@@ -300,8 +300,8 @@ class WorkflowTaskStatus:
                  f"\tscan task ID: {status.scan_task_id}\n" \
                  f"\tpatch status: {status.patch_status}\n"
 
-        if hasattr(status, "skipped_patch_reason"):
-            result += f"\tskipped patch reason: {status.skipped_patch_reason}\n"
+        if hasattr(status, "patch_skipped_reason"):
+            result += f"\tpatch skipped reason: {status.patch_skipped_reason}\n"
 
         result += f"\tpatch date: {status.patch_date}\n" \
                   f"\tpatch task ID: {status.patch_task_id}\n" \

--- a/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
@@ -254,7 +254,6 @@ class WorkflowTaskStatus:
                 patch_task = next(task for task in patch_taskruns if task.run_id == patch_task_id)
                 all_status[image].patch_task = patch_task
 
-        # don't return a list of WorkflowTaskStatus object, 
         return [status.get_status() for status in all_status.values()]
 
     def get_status(self):

--- a/src/acrcssc/setup.py
+++ b/src/acrcssc/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '1.1.1rc5'
+VERSION = '1.1.1rc7'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
To make the output of the `list` command easier to read, renamed `skipped_patch_reason` to `patch_skipped_reason`.

```
az acr supply-chain workflow list ...
Total images: 14
[
  {
    "image": "import:dotnetapp-manual",
    "last_patched_image": "import:dotnetapp-manual-1",
    "patch_date": "---Not Available---",
    "patch_skipped_reason": "no vulnerability found in the image import:dotnetapp-manual-1",
    "patch_status": "Skipped",
    "patch_task_ID": "---Not Available---",
    "scan_date": "2025-01-23T17:56:27.412952+00:00",
    "scan_status": "Succeeded",
    "scan_task_ID": "dt23a",
    "workflow_type": "continuouspatchv1"
  },
...
```