### PR TITLE
fix(cssc): task files cleanup

### DIFF
--- a/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
@@ -128,7 +128,7 @@ class WorkflowTaskStatus:
             original_tag = match.group(2)
             return f"{repository}:{original_tag}"
 
-        match = re.search(r'Scanning image for vulnerability (\S+) for tag (\S+)', logs)
+        match = re.search(r'Scanning image for vulnerability(?: and patch)? (\S+) for tag (\S+)', logs)        
         if match:
             patched_image = match.group(1)
             original_tag = match.group(2)

--- a/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
@@ -128,14 +128,14 @@ class WorkflowTaskStatus:
             original_tag = match.group(2)
             return f"{repository}:{original_tag}"
 
-        match = re.search(r'Scanning image for vulnerability and patch (\S+) for tag (\S+)', logs)
+        match = re.search(r'Scanning image for vulnerability (\S+) for tag (\S+)', logs)
         if match:
             patched_image = match.group(1)
             original_tag = match.group(2)
             repository = patched_image.split(':')[0]
             return f"{repository}:{original_tag}"
 
-        match = re.search(r'Scan, Upload scan report and Schedule Patch for (\S+)', logs)
+        match = re.search(r'Patching OS vulnerabilities for image (\S+)', logs)
         if match:
             return match.group(1)
         return None

--- a/src/acrcssc/azext_acrcssc/templates/task/cssc_patch_image.yaml
+++ b/src/acrcssc/azext_acrcssc/templates/task/cssc_patch_image.yaml
@@ -4,8 +4,13 @@ alias:
     ScanReport : os-vulnerability-report_trivy_{{ regexReplaceAll "[^a-zA-Z0-9]" .Values.SOURCE_REPOSITORY "-" }}_{{.Values.SOURCE_IMAGE_TAG}}_$(date "+%Y-%m-%d").json
     cssc : mcr.microsoft.com/acr/cssc:0995fb8
 steps:
+  # Step 1: Print the inputs  
+  - id: print-inputs
+    cmd: |
+        bash -c 'echo "Scan, Upload scan report and Schedule Patch for {{.Values.SOURCE_REPOSITORY}}:{{.Values.SOURCE_IMAGE_TAG}}"'
+        bash -c 'echo "Patching repo: {{.Values.SOURCE_REPOSITORY}}, Tag:{{.Values.SOURCE_IMAGE_TAG}}, NewPatchTag:{{.Values.SOURCE_IMAGE_NEWPATCH_TAG}}"'
 
-  # Step 1: Check if new patch tag is greate than 999 by extracting the digits after the last hyphen
+  # Step 2: Check if new patch tag is greater than 999 by extracting the digits after the last hyphen
   - id: check-patch-tag
     cmd: |
        bash -c 'echo "New Patch tag is {{.Values.SOURCE_IMAGE_NEWPATCH_TAG}}"
@@ -13,10 +18,8 @@ steps:
           echo "New Patch tag is greater than 999. No more than 1000 patches can be created for a tag. Exiting the patching workflow."
           exit 1
        fi'
-  # Step 2: Perform the vulnerability scan
-  - id: print-inputs
-    cmd: |
-        bash -c 'echo "Scan, Upload scan report and Schedule Patch for {{.Values.SOURCE_REPOSITORY}}:{{.Values.SOURCE_IMAGE_TAG}}"'
+
+  # Step 3: Perform the vulnerability scan
   - id: setup-data-dir
     cmd: bash mkdir ./data
   - id: generate-trivy-report
@@ -34,26 +37,13 @@ steps:
       --db-repository "ghcr.io/aquasecurity/trivy-db:2","public.ecr.aws/aquasecurity/trivy-db" \
       --output /workspace/data/$ScanReport
 
-  # Step 3: Attach the vulnerability scan report to the image
-  - id: upload-trivy-report
-    cmd: |
-      cssc oras attach \
-      --artifact-type vulnerabilityScan/report \
-      {{.Run.Registry}}/{{.Values.SOURCE_REPOSITORY}}:{{.Values.SOURCE_IMAGE_TAG}} \
-      ./data/$ScanReport
-
-  - cmd: bash echo "Uploaded vulnerability report $ScanReport to the image {{.Values.SOURCE_REPOSITORY}}:{{.Values.SOURCE_IMAGE_TAG}}"
-
   - id: buildkitd
     cmd: moby/buildkit --addr tcp://0.0.0.0:8888
     entrypoint: buildkitd
     detach: true
     privileged: true
     ports: ["127.0.0.1:8888:8888/tcp"]
-  
-  - id: list-output-file
-    cmd: bash ls -l /workspace/data
-  
+ 
   # Step 4: Patch the image with Copacetic
   - id: patch-image
     retries: 3
@@ -68,6 +58,7 @@ steps:
       --addr tcp://127.0.0.1:8888
     network: host
 
+  # Step 5: Push the patched image to the registry
   - id: push-image
     retries: 3
     retryDelay: 3

--- a/src/acrcssc/azext_acrcssc/templates/task/cssc_patch_image.yaml
+++ b/src/acrcssc/azext_acrcssc/templates/task/cssc_patch_image.yaml
@@ -7,7 +7,7 @@ steps:
   # Step 1: Print the inputs  
   - id: print-inputs
     cmd: |
-        bash -c 'echo "Scan, Upload scan report and Schedule Patch for {{.Values.SOURCE_REPOSITORY}}:{{.Values.SOURCE_IMAGE_TAG}}"'
+        bash -c 'echo "Patching OS vulnerabilities for image {{.Values.SOURCE_REPOSITORY}}:{{.Values.SOURCE_IMAGE_TAG}}"'
         bash -c 'echo "Patching repo: {{.Values.SOURCE_REPOSITORY}}, Tag:{{.Values.SOURCE_IMAGE_TAG}}, NewPatchTag:{{.Values.SOURCE_IMAGE_NEWPATCH_TAG}}"'
 
   # Step 2: Check if new patch tag is greater than 999 by extracting the digits after the last hyphen

--- a/src/acrcssc/azext_acrcssc/templates/task/cssc_patch_image.yaml
+++ b/src/acrcssc/azext_acrcssc/templates/task/cssc_patch_image.yaml
@@ -4,13 +4,11 @@ alias:
     ScanReport : os-vulnerability-report_trivy_{{ regexReplaceAll "[^a-zA-Z0-9]" .Values.SOURCE_REPOSITORY "-" }}_{{.Values.SOURCE_IMAGE_TAG}}_$(date "+%Y-%m-%d").json
     cssc : mcr.microsoft.com/acr/cssc:0995fb8
 steps:
-  # Step 1: Print the inputs  
   - id: print-inputs
     cmd: |
         bash -c 'echo "Patching OS vulnerabilities for image {{.Values.SOURCE_REPOSITORY}}:{{.Values.SOURCE_IMAGE_TAG}}"'
         bash -c 'echo "Patching repo: {{.Values.SOURCE_REPOSITORY}}, Tag:{{.Values.SOURCE_IMAGE_TAG}}, NewPatchTag:{{.Values.SOURCE_IMAGE_NEWPATCH_TAG}}"'
 
-  # Step 2: Check if new patch tag is greater than 999 by extracting the digits after the last hyphen
   - id: check-patch-tag
     cmd: |
        bash -c 'echo "New Patch tag is {{.Values.SOURCE_IMAGE_NEWPATCH_TAG}}"
@@ -19,12 +17,11 @@ steps:
           exit 1
        fi'
 
-  # Step 3: Perform the vulnerability scan
   - id: setup-data-dir
     cmd: bash mkdir ./data
   - id: generate-trivy-report
     retries: 3
-    retryDelay: 3
+    retryDelay: 5
     timeout: 1800
     cmd: |
       cssc trivy image \
@@ -44,10 +41,9 @@ steps:
     privileged: true
     ports: ["127.0.0.1:8888:8888/tcp"]
  
-  # Step 4: Patch the image with Copacetic
   - id: patch-image
     retries: 3
-    retryDelay: 3
+    retryDelay: 5
     timeout: 1800
     cmd: |
       cssc copa patch \
@@ -58,11 +54,9 @@ steps:
       --addr tcp://127.0.0.1:8888
     network: host
 
-  # Step 5: Push the patched image to the registry
   - id: push-image
     retries: 3
-    retryDelay: 3
+    retryDelay: 5
     timeout: 1800
     cmd: docker push {{.Run.Registry}}/{{.Values.SOURCE_REPOSITORY}}:{{.Values.SOURCE_IMAGE_TAG}}-{{.Values.SOURCE_IMAGE_NEWPATCH_TAG}}
-
   - cmd: bash echo "Patched image pushed to {{.Run.Registry}}/{{.Values.SOURCE_REPOSITORY}}:{{.Values.SOURCE_IMAGE_TAG}}-{{.Values.SOURCE_IMAGE_NEWPATCH_TAG}}"

--- a/src/acrcssc/azext_acrcssc/templates/task/cssc_scan_image.yaml
+++ b/src/acrcssc/azext_acrcssc/templates/task/cssc_scan_image.yaml
@@ -14,7 +14,7 @@ steps:
 
   - id: generate-trivy-report
     retries: 3
-    retryDelay: 3
+    retryDelay: 5
     timeout: 1800
     cmd: |
       cssc trivy image \

--- a/src/acrcssc/azext_acrcssc/templates/task/cssc_scan_image.yaml
+++ b/src/acrcssc/azext_acrcssc/templates/task/cssc_scan_image.yaml
@@ -7,7 +7,7 @@ alias:
 steps:
   - id: print-inputs
     cmd: |
-        bash -c 'echo "Scanning image for vulnerability and patch {{.Values.SOURCE_REPOSITORY}}:{{.Values.SOURCE_IMAGE_TAG}} for tag {{.Values.SOURCE_IMAGE_ORIGINAL_TAG}}"'
+        bash -c 'echo "Scanning image for vulnerability {{.Values.SOURCE_REPOSITORY}}:{{.Values.SOURCE_IMAGE_TAG}} for tag {{.Values.SOURCE_IMAGE_ORIGINAL_TAG}}"'
         bash -c 'echo "Scanning repo: {{.Values.SOURCE_REPOSITORY}}, Tag:{{.Values.SOURCE_IMAGE_TAG}}, OriginalTag:{{.Values.SOURCE_IMAGE_ORIGINAL_TAG}}"'
   - id: setup-data-dir
     cmd: bash mkdir ./data


### PR DESCRIPTION
- Updated print command statements
- Removed the step to attach the vulnerability scan report to the image and list output file
- Removed comments from the yaml
- Increased delay between retries
