### PR TITLE
feat(cssc): 31196178, 30937992 add fields for scan_error_reason and patch_error_reason to 'list' command output

### DIFF
--- a/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
@@ -190,9 +190,8 @@ class WorkflowTaskStatus:
         match = re.findall(r'(?i)\b(error\b.*)', tasklog)
         # TODO: should we filter out any error?
         if match:
-            # retrieve only unique errors
-            # TODO is the order important?
-            return str.join("\n", set(match))
+            # retrieve only unique errors, sort them to make the output deterministic
+            return str.join("\n", sorted(set(match)))
         return None
 
     def _get_patched_image_name_from_tasklog(self):


### PR DESCRIPTION
Modify the list command output to display an error reason for when a scan or patch task is marked as failed.

Since the log output is not controlled by the task nor the ACR cli, for now the approach will be 'naive' and just regex lines of the output that contain the word `error` when a task is in a `failed` state. This will allow us to test the command and measure the usability of the output and improve it further.

This change is able to display errors such as, apt/yum/repository update issues, mentions of unsupported images, errors while reading/downloading layers, throttling, among others.

The error reason is split between scan and patch, but these can be merged if deemed necessary, as a failed scan will not trigger a patch task, and a failed patch indicates that the scan task that spawned it succeeded.

Examples of the output:

```
{
    "image": "dotnet-samples-cache:aspnetapp-jammy-chiseled-composite-amd64",
    "last_patched_image": "---No patch image available---",
    "patch_date": "2025-02-04T23:45:35.804876+00:00",
    "patch_error_reason": "Error response from registry: unsupported: pushes to repository 'dotnet-samples-cache' matching cache rule 'dotnet-samples-cache' are not supported. CorrelationId: e6e7c1be-7b9c-425b-8b00-2fe68c7e248c. For more information, please visit https://aka.ms/acr/cache.\nError: failed during run, err: exit status 1\r",
    "patch_status": "Failed",
    "patch_task_ID": "dt2hv",
    "scan_date": "2025-02-04T23:45:07.553595+00:00",
    "scan_status": "Succeeded",
    "scan_task_ID": "dt2hq",
    "workflow_type": "continuouspatchv1"
  },
{
    "image": "import:openmpi-4.1.5-1-azl3.0.20240727-amd64",
    "last_patched_image": "---No patch image available---",
    "patch_date": "2025-02-04T23:46:17.911506+00:00",
    "patch_error_reason": "Error: failed during run, err: exit status 1\r\nError: unsupported osType azurelinux specified",
    "patch_status": "Failed",
    "patch_task_ID": "dt2ja",
    "scan_date": "2025-02-04T23:45:44.469753+00:00",
    "scan_status": "Succeeded",
    "scan_task_ID": "dt2j0",
    "workflow_type": "continuouspatchv1"
  },
{
    "image": "import:dotnet-samples-aspnetapp-jammy-chiseled-composite-amd64",
    "last_patched_image": "---No patch image available---",
    "patch_date": "2025-02-04T23:46:51.155158+00:00",
    "patch_error_reason": "ERROR: process \"apt update\" did not complete successfully: exit code: 1\nError: failed during run, err: exit status 1\r\nError: process \"apt update\" did not complete successfully: exit code: 1\nerror during container init: exec: \"apt\": executable file not found in $PATH",
    "patch_status": "Failed",
    "patch_task_ID": "dt2jd",
    "scan_date": "2025-02-04T23:46:09.900401+00:00",
    "scan_status": "Succeeded",
    "scan_task_ID": "dt2j7",
    "workflow_type": "continuouspatchv1"
  },
```
