### PR TITLE
feat(cssc): 31084399 cssc image update to use source policy

### DIFF
--- a/src/acrcssc/azext_acrcssc/templates/task/cssc_patch_image.yaml
+++ b/src/acrcssc/azext_acrcssc/templates/task/cssc_patch_image.yaml
@@ -2,7 +2,7 @@ version: v1.1.0
 alias:
   values:
     ScanReport : os-vulnerability-report_trivy_{{ regexReplaceAll "[^a-zA-Z0-9]" .Values.SOURCE_REPOSITORY "-" }}_{{.Values.SOURCE_IMAGE_TAG}}_$(date "+%Y-%m-%d").json
-    cssc : mcr.microsoft.com/acr/cssc:f86c1b6
+    cssc : mcr.microsoft.com/acr/cssc:9fb281c
 steps:
   - id: print-inputs
     cmd: |
@@ -40,7 +40,7 @@ steps:
     detach: true
     privileged: true
     ports: ["127.0.0.1:8888:8888/tcp"]
- 
+
   - id: patch-image
     retries: 3
     retryDelay: 5

--- a/src/acrcssc/azext_acrcssc/templates/task/cssc_scan_image.yaml
+++ b/src/acrcssc/azext_acrcssc/templates/task/cssc_scan_image.yaml
@@ -3,7 +3,7 @@ alias:
   values:
     patchimagetask: cssc-patch-image
     DATE: $(date "+%Y-%m-%d")
-    cssc : mcr.microsoft.com/acr/cssc:f86c1b6
+    cssc : mcr.microsoft.com/acr/cssc:9fb281c
 steps:
   - id: print-inputs
     cmd: |

--- a/src/acrcssc/azext_acrcssc/templates/task/cssc_trigger_workflow.yaml
+++ b/src/acrcssc/azext_acrcssc/templates/task/cssc_trigger_workflow.yaml
@@ -2,7 +2,7 @@ version: v1.1.0
 alias:
   values:
     ScanImageAndSchedulePatchTask: cssc-scan-image
-    cssc : mcr.microsoft.com/acr/cssc:f86c1b6
+    cssc : mcr.microsoft.com/acr/cssc:9fb281c
     maxLimit: 100
 steps:
   - cmd: bash -c 'echo "Inside cssc-trigger-workflow task, getting list of images to be patched based on --filter-policy for Registry {{.Run.Registry}}."'

--- a/src/acrcssc/azext_acrcssc/templates/tmp_dry_run_template.yaml
+++ b/src/acrcssc/azext_acrcssc/templates/tmp_dry_run_template.yaml
@@ -1,7 +1,7 @@
 version: v1.1.0
 alias:
   values:
-    cssc : mcr.microsoft.com/acr/cssc:f86c1b6
+    cssc : mcr.microsoft.com/acr/cssc:9fb281c
     maxLimit: 100
 steps:
   - id: acr-cli-filter


### PR DESCRIPTION
Updated cssc image to use source policy to fix docker throttling issue during tooling image pull for DPKG based images.
This was a blocker for Public Preview.

For Ubuntu based images, verified that the tooling image is now pulled from MCR instead of docker:
![image](https://github.com/user-attachments/assets/c1354474-260c-4eb1-a974-27d96f0a22b3)

For Debian, this will start working once the OSS upstream image PR completes.

