### PR TITLE
feat(cssc): 31482353 changes to pull buildkit from cached image in buildhost

### DIFF
--- a/src/acrcssc/azext_acrcssc/templates/task/cssc_patch_image.yaml
+++ b/src/acrcssc/azext_acrcssc/templates/task/cssc_patch_image.yaml
@@ -35,7 +35,7 @@ steps:
       --output /workspace/data/$ScanReport
 
   - id: buildkitd
-    cmd: moby/buildkit --addr tcp://0.0.0.0:8888
+    cmd: mobybuildkit --addr tcp://0.0.0.0:8888
     entrypoint: buildkitd
     detach: true
     privileged: true


### PR DESCRIPTION
Changes to use the cached buildkit image from buildhost instead of docker
With this, buildkitd step doesn't pull anymore from docker

![image](https://github.com/user-attachments/assets/470dbf39-2c53-46bc-97db-87e7e7b9dcc9)

Verified that this change works in Canary.

For this to work in all regions, Feb Task deployment should complete in all regions which is by early next week.
