### PR TITLE
fix(cssc): 31670277 Remove LongRunningOperation wrapper for task updates

### DIFF
--- a/src/acrcssc/azext_acrcssc/helper/_taskoperations.py
+++ b/src/acrcssc/azext_acrcssc/helper/_taskoperations.py
@@ -368,11 +368,10 @@ def _update_task_yaml(cmd, acr_task_client, registry, resource_group_name, task,
             step=acr_task_client.models.EncodedTaskStepUpdateParameters(
                 encoded_task_content=encoded_task))
 
-        result = LongRunningOperation(cmd.cli_ctx)(
-            acr_task_client.begin_update(resource_group_name,
-                                         registry.name,
-                                         task.name,
-                                         taskUpdateParameters))
+        result = acr_task_client.begin_update(resource_group_name,
+                                              registry.name,
+                                              task.name,
+                                              taskUpdateParameters)
 
         logger.debug(f"Task {task.name} updated successfully")
     except HttpResponseError as exception:
@@ -393,11 +392,10 @@ def _update_task_schedule(cmd, acr_task_client, registry, resource_group_name, c
         logger.debug("Dry run, skipping the update of the task schedule")
         return
     try:
-        result = LongRunningOperation(cmd.cli_ctx)(
-            acr_task_client.begin_update(resource_group_name,
-                                         registry.name,
-                                         CONTINUOUSPATCH_TASK_SCANREGISTRY_NAME,
-                                         taskUpdateParameters))
+        result = acr_task_client.begin_update(resource_group_name,
+                                              registry.name,
+                                              CONTINUOUSPATCH_TASK_SCANREGISTRY_NAME,
+                                              taskUpdateParameters)
         print("Schedule has been successfully updated.")
     except HttpResponseError as exception:
         raise AzCLIError(f"Failed to update the task schedule: {exception}")


### PR DESCRIPTION
To avoid hitting the issue around "Discriminator type is absent or null, use base class TaskStepProperties" when the Task update is performed as a LongRunningOperation, it is better to remove the wrapper.
This keeps functionality intact as the operation will still be done, but is not tracked by the poller