### PR TITLE
fix(cssc): 31694219 inform user when images matching their configuration are 0

### DIFF
--- a/src/acrcssc/azext_acrcssc/_validators.py
+++ b/src/acrcssc/azext_acrcssc/_validators.py
@@ -168,3 +168,10 @@ def validate_continuous_patch_v1_image_limit(dryrun_log):
         result = re.sub(r'(?s)' + re.escape(pattern_postfix) + r'.*', pattern_postfix, result)
 
         raise InvalidArgumentValueError(error_msg=result)
+    
+    if image_limit == 0:
+        # when no matching images are found, we should relay the information to the user
+        # extract everything between and including the target lines
+        match = re.search(r'No matching repository and tag found!.*?Matches found: 0', dryrun_log, re.DOTALL)
+        if match:
+            logger.warning(match.group())

--- a/src/acrcssc/azext_acrcssc/cssc.py
+++ b/src/acrcssc/azext_acrcssc/cssc.py
@@ -47,11 +47,11 @@ def _perform_continuous_patch_operation(cmd,
     # every time we perform a create or update operation, we need to validate for the number of images selected on the
     # configuration file. The way to do this is by silently running the dryrun operation. If the limit is exceeded, we
     # will not proceed with the operation.
-    dryrun_output = acr_cssc_dry_run(cmd, registry=registry, config_file_path=config, is_create=is_create, remove_internal_statements=not dryrun)
-    validate_continuous_patch_v1_image_limit(dryrun_output)
+    dryrun_output = acr_cssc_dry_run(cmd, registry=registry, config_file_path=config, is_create=is_create, remove_internal_statements=not dryrun)    
     if dryrun:
         print(dryrun_output)
     else:
+        validate_continuous_patch_v1_image_limit(dryrun_output)
         create_update_continuous_patch_v1(cmd, registry, config, schedule, dryrun, run_immediately, is_create)
 
 


### PR DESCRIPTION
During dry-run, we inform the user if images matching their configuration = 0.
However, currently, during actual create/update, this information is lost.

With this fix, I am basically matching up the dry-run and actual run logs by relaying this information to the user.
Intentionally not blocking the create/update operation - for the scenarios when user wants to create the patching workflow first and later wants to push relevant images.

Bug - https://msazure.visualstudio.com/AzureContainerRegistry/_workitems/edit/31694219/?view=edit

Behavior after fix on Update...
![image](https://github.com/user-attachments/assets/b1168dae-4cf2-4690-9a55-2162053caa10)

Behavior after fix on Create..
![image](https://github.com/user-attachments/assets/53d2b651-f716-4ce5-a7fb-299b58883e27)
