### PR TITLE
fix(cssc): 31695069 Enhanced repositories schema validation + added tests

### DIFF
--- a/src/acrcssc/azext_acrcssc/helper/_constants.py
+++ b/src/acrcssc/azext_acrcssc/helper/_constants.py
@@ -126,7 +126,9 @@ CONTINUOUSPATCH_CONFIG_SCHEMA_V1 = {
                     }
                 },
                 "required": ["repository", "tags"]
-            }
+            },
+            "uniqueItems": True,
+            "minItems": 1
         }
     },
     "required": ["repositories", "version"]

--- a/src/acrcssc/azext_acrcssc/tests/latest/test_validators.py
+++ b/src/acrcssc/azext_acrcssc/tests/latest/test_validators.py
@@ -124,12 +124,47 @@ class AcrCsscCommandsTests(unittest.TestCase):
         with tempfile.NamedTemporaryFile(delete=False) as temp_file:
             temp_file_path = temp_file.name
 
+        # Test when version is missing
         mock_invalid_config = {
             "repositories": [
                 {
                     "repository": "docker-local",
                     "tags": ["v1"],
                 }]
+        }
+        mock_load.return_value = mock_invalid_config
+
+        with patch('os.path.exists', return_value=True), \
+             patch('os.path.isfile', return_value=True), \
+             patch('os.path.getsize', return_value=100), \
+             patch('os.access', return_value=True):
+            self.assertRaises(AzCLIError, validate_continuouspatch_config_v1, temp_file_path)
+
+        # Test when repositories is empty
+        mock_invalid_config = {
+            "repositories": [],
+            "version": "v1"
+        }
+        mock_load.return_value = mock_invalid_config
+
+        with patch('os.path.exists', return_value=True), \
+             patch('os.path.isfile', return_value=True), \
+             patch('os.path.getsize', return_value=100), \
+             patch('os.access', return_value=True):
+            self.assertRaises(AzCLIError, validate_continuouspatch_config_v1, temp_file_path)
+
+        # Test when same repository is repeated
+        mock_invalid_config = {
+            "repositories": [
+                {
+                    "repository": "docker-local",
+                    "tags": ["v1"],
+                },
+                {
+                    "repository": "docker-local",
+                    "tags": ["v1"],
+                }],
+            "version": "v1"
         }
         mock_load.return_value = mock_invalid_config
 
@@ -149,7 +184,8 @@ class AcrCsscCommandsTests(unittest.TestCase):
                 {
                     "repository": "docker-local",
                     "tags": ["v1-patched"],
-                }]
+                }],
+            "version": "v1"
         }
         mock_load.return_value = mock_invalid_config
 
@@ -165,6 +201,7 @@ class AcrCsscCommandsTests(unittest.TestCase):
                     "repository": "docker-local",
                     "tags": ["v1-999"],
                 }],
+            "version": "v1"
         }
         mock_load.return_value = mock_invalid_config
 


### PR DESCRIPTION
Currently, no validation error is thrown when repositories are empty or repeated in configuration file.

Bug - https://msazure.visualstudio.com/AzureContainerRegistry/_workitems/edit/31695069/?view=edit

This PR fixes the issue by enhancing schema validation for repositories and updating the tests to test for this scenario.

![image](https://github.com/user-attachments/assets/1d7d1f0e-feff-49b1-a955-2dbb85c44ab2)
