### PR TITLE
fix(cssc): 31694510, 31694600 Check for existence of cssc tasks before calling list command + enhance log message

### DIFF
--- a/src/acrcssc/azext_acrcssc/cssc.py
+++ b/src/acrcssc/azext_acrcssc/cssc.py
@@ -145,7 +145,4 @@ def list_scan_status(cmd, registry_name, resource_group_name, status, workflow_t
     acr_client_registries = cf_acr_registries(cmd.cli_ctx, None)
     registry = acr_client_registries.get(resource_group_name, registry_name)
 
-    image_status = track_scan_progress(cmd, resource_group_name, registry, status)
-    print(f"Total images: {len(image_status)}")
-
-    return image_status
+    return track_scan_progress(cmd, resource_group_name, registry, status)

--- a/src/acrcssc/azext_acrcssc/helper/_constants.py
+++ b/src/acrcssc/azext_acrcssc/helper/_constants.py
@@ -67,6 +67,8 @@ WORKFLOW_STATUS_NOT_AVAILABLE = "---Not Available---"
 WORKFLOW_STATUS_PATCH_NOT_AVAILABLE = "---No patch image available---"
 WORKFLOW_VALIDATION_MESSAGE = "Validating configuration"
 
+ERROR_MESSAGE_WORKFLOW_TASKS_DOES_NOT_EXIST = f"{CONTINUOUS_PATCHING_WORKFLOW_NAME} workflow tasks does not exist. Run 'az acr supply-chain workflow create' command to create workflow tasks."
+ERROR_MESSAGE_WORKFLOW_TASKS_ALREADY_EXISTS = f"{CONTINUOUS_PATCHING_WORKFLOW_NAME} workflow tasks already exists. Use 'az acr supply-chain workflow update' command to perform updates."
 ERROR_MESSAGE_INVALID_TASK = "Workflow type is invalid"
 ERROR_MESSAGE_INVALID_TIMESPAN_VALUE = "Schedule value is invalid. "
 ERROR_MESSAGE_INVALID_TIMESPAN_FORMAT = "Schedule format is invalid. "

--- a/src/acrcssc/azext_acrcssc/helper/_taskoperations.py
+++ b/src/acrcssc/azext_acrcssc/helper/_taskoperations.py
@@ -23,6 +23,8 @@ from ._constants import (
     CONTINUOUSPATCH_OCI_ARTIFACT_CONFIG_TAG_V1,
     TMP_DRY_RUN_FILE_NAME,
     CONTINUOUS_PATCHING_WORKFLOW_NAME,
+    ERROR_MESSAGE_WORKFLOW_TASKS_DOES_NOT_EXIST,
+    ERROR_MESSAGE_WORKFLOW_TASKS_ALREADY_EXISTS,
     CSSC_WORKFLOW_POLICY_REPOSITORY,
     CONTINUOUSPATCH_TASK_PATCHIMAGE_NAME,
     CONTINUOUSPATCH_TASK_SCANIMAGE_NAME,
@@ -68,11 +70,11 @@ def create_update_continuous_patch_v1(cmd,
     cssc_tasks_exists, task_list = check_continuous_task_exists(cmd, registry)
     if is_create_workflow:
         if cssc_tasks_exists:
-            raise AzCLIError(f"{CONTINUOUS_PATCHING_WORKFLOW_NAME} workflow task already exists. Use 'az acr supply-chain workflow update' command to perform updates.")
+            raise AzCLIError(f"{ERROR_MESSAGE_WORKFLOW_TASKS_ALREADY_EXISTS}")
         _create_cssc_workflow(cmd, registry, schedule_cron_expression, resource_group, dryrun)
     else:
         if not cssc_tasks_exists:
-            raise AzCLIError(f"{CONTINUOUS_PATCHING_WORKFLOW_NAME} workflow task does not exist. Use 'az acr supply-chain workflow create' command to create {CONTINUOUS_PATCHING_WORKFLOW_NAME} workflow.")
+            raise AzCLIError(f"{ERROR_MESSAGE_WORKFLOW_TASKS_DOES_NOT_EXIST}")
 
         _update_cssc_workflow(cmd, registry, schedule_cron_expression, resource_group, dryrun, task_list)
 
@@ -158,14 +160,13 @@ def delete_continuous_patch_v1(cmd, registry, dryrun):
         delete_oci_artifact_continuous_patch(cmd, registry, dryrun)
 
     if not cssc_tasks_exists:
-        logger.warning(f"{CONTINUOUS_PATCHING_WORKFLOW_NAME} workflow does not exist")
-
+        logger.warning(f"{ERROR_MESSAGE_WORKFLOW_TASKS_DOES_NOT_EXIST}")        
 
 def list_continuous_patch_v1(cmd, registry):
     logger.debug("Entering list_continuous_patch_v1")
     cssc_tasks_exists, _ = check_continuous_task_exists(cmd, registry)
     if not cssc_tasks_exists:
-        logger.warning(f"{CONTINUOUS_PATCHING_WORKFLOW_NAME} workflow task does not exist. Run 'az acr supply-chain workflow create' to create workflow tasks")
+        logger.warning(f"{ERROR_MESSAGE_WORKFLOW_TASKS_DOES_NOT_EXIST}")
         return
 
     acr_task_client = cf_acr_tasks(cmd.cli_ctx)
@@ -190,7 +191,7 @@ def acr_cssc_dry_run(cmd, registry, config_file_path, is_create=True, remove_int
             raise AzCLIError("Failed to retrieve the configuration file from the registry.")
 
     if is_create and cssc_tasks_exists:
-        raise AzCLIError(f"{CONTINUOUS_PATCHING_WORKFLOW_NAME} workflow task already exists. Use 'az acr supply-chain workflow update' command to perform updates.")
+        raise AzCLIError(f"{ERROR_MESSAGE_WORKFLOW_TASKS_ALREADY_EXISTS}")
 
     file_name = None
     tmp_folder = None
@@ -287,7 +288,7 @@ def track_scan_progress(cmd, resource_group_name, registry, status):
 
     cssc_tasks_exists, _ = check_continuous_task_exists(cmd, registry)
     if not cssc_tasks_exists:
-        logger.warning(f"{CONTINUOUS_PATCHING_WORKFLOW_NAME} workflow task does not exist. Run 'az acr supply-chain workflow create' to create workflow tasks")
+        logger.warning(f"{ERROR_MESSAGE_WORKFLOW_TASKS_DOES_NOT_EXIST}")
         return
 
     config, _ = get_oci_artifact_continuous_patch(cmd, registry)

--- a/src/acrcssc/azext_acrcssc/helper/_taskoperations.py
+++ b/src/acrcssc/azext_acrcssc/helper/_taskoperations.py
@@ -285,9 +285,17 @@ def cancel_continuous_patch_runs(cmd, resource_group_name, registry_name):
 def track_scan_progress(cmd, resource_group_name, registry, status):
     logger.debug("Entering track_scan_progress")
 
+    cssc_tasks_exists, _ = check_continuous_task_exists(cmd, registry)
+    if not cssc_tasks_exists:
+        logger.warning(f"{CONTINUOUS_PATCHING_WORKFLOW_NAME} workflow task does not exist. Run 'az acr supply-chain workflow create' to create workflow tasks")
+        return
+
     config, _ = get_oci_artifact_continuous_patch(cmd, registry)
 
-    return _retrieve_logs_for_image(cmd, registry, resource_group_name, config.schedule, status)
+    image_status = _retrieve_logs_for_image(cmd, registry, resource_group_name, config.schedule, status)
+    print(f"Listing images that have been scanned and/or patched in the last {config.schedule} days")
+    print(f"Total images: {len(image_status) if image_status else 0}")
+    return image_status
 
 
 def _retrieve_logs_for_image(cmd, registry, resource_group_name, schedule, workflow_status=None):

--- a/src/acrcssc/azext_acrcssc/tests/latest/test_helper_taskoperations.py
+++ b/src/acrcssc/azext_acrcssc/tests/latest/test_helper_taskoperations.py
@@ -251,10 +251,12 @@ class TestCreateContinuousPatchV1(unittest.TestCase):
         mock_get_taskruns_with_filter.assert_called_once()
         mock_acr_task_run_client.begin_cancel.assert_called_once()
 
+    @mock.patch("azext_acrcssc.helper._taskoperations.check_continuous_task_exists")
     @mock.patch("azext_acrcssc.helper._taskoperations.get_oci_artifact_continuous_patch")
     @mock.patch("azext_acrcssc.helper._taskoperations._retrieve_logs_for_image")
-    def test_track_scan_progress(self, mock_retrieve_logs_for_image, mock_get_oci_artifact_continuous_patch):
+    def test_track_scan_progress(self, mock_retrieve_logs_for_image, mock_get_oci_artifact_continuous_patch, mock_check_continuous_task_exists):
         # Mock the necessary dependencies
+        mock_check_continuous_task_exists.return_value = True, []
         resource_group_name = "test_rg"
         status = "test_status"
         mock_get_oci_artifact_continuous_patch.return_value = mock.MagicMock(schedule="1d"), mock.MagicMock()
@@ -263,6 +265,7 @@ class TestCreateContinuousPatchV1(unittest.TestCase):
         result = track_scan_progress(self.cmd, resource_group_name, self.registry, status)
 
         # Assert that the dependencies were called with the correct arguments
+        mock_check_continuous_task_exists.assert_called_once()
         mock_get_oci_artifact_continuous_patch.assert_called_once()
         mock_retrieve_logs_for_image.assert_called_once()
         self.assertIsNotNone(result)


### PR DESCRIPTION
This PR adds a check to ensure that the cssc tasks exist before calling the list command. It also displays that the list command is executed for the last n days. Updated tests as well.

With this, below 2 bugs are addressed:
1. https://msazure.visualstudio.com/AzureContainerRegistry/_workitems/edit/31694510/?view=edit
Before Fix: 
![image](https://github.com/user-attachments/assets/61ced20f-d8c4-42d6-bc8d-67e3ae299ed1)
After Fix:
![image](https://github.com/user-attachments/assets/807745a3-71f5-471c-89b5-62161fbd3fd1)

2. https://msazure.visualstudio.com/AzureContainerRegistry/_workitems/edit/31694600/?view=edit
After Fix: added a line to indicate list executed for last n days:
![image](https://github.com/user-attachments/assets/fe832467-d337-4f18-a2c7-f713452e5c3a)
