### PR TITLE
fix(cssc): 31694592 Added validations to ensure dry run and run immediately options are mutually exclusive

### DIFF
--- a/src/acrcssc/azext_acrcssc/_validators.py
+++ b/src/acrcssc/azext_acrcssc/_validators.py
@@ -134,10 +134,16 @@ def _validate_schedule(schedule):
         raise InvalidArgumentValueError(error_msg=ERROR_MESSAGE_INVALID_TIMESPAN_VALUE, recommendation=RECOMMENDATION_SCHEDULE)
 
 
-def validate_inputs(schedule, config_file_path=None):
+def validate_inputs(schedule, config_file_path=None, dryrun=False, run_immediately=False):
     _validate_schedule(schedule)
     if config_file_path is not None:
         validate_continuouspatch_config_v1(config_file_path)
+    validate_run_type(dryrun, run_immediately)
+    
+
+def validate_run_type(dryrun, run_immediately):
+    if dryrun and run_immediately:
+        raise InvalidArgumentValueError(error_msg="The --dryrun and --run-immediately options cannot be used together. Use one or the other.")
 
 
 def validate_task_type(task_type):

--- a/src/acrcssc/azext_acrcssc/cssc.py
+++ b/src/acrcssc/azext_acrcssc/cssc.py
@@ -37,7 +37,7 @@ def _perform_continuous_patch_operation(cmd,
     acr_client_registries = cf_acr_registries(cmd.cli_ctx, None)
     registry = acr_client_registries.get(resource_group_name, registry_name)
 
-    validate_inputs(schedule, config)
+    validate_inputs(schedule, config, dryrun, run_immediately)
 
     if not is_create:
         validate_cssc_optional_inputs(config, schedule)

--- a/src/acrcssc/azext_acrcssc/tests/latest/test_validators.py
+++ b/src/acrcssc/azext_acrcssc/tests/latest/test_validators.py
@@ -8,7 +8,7 @@ import tempfile
 import unittest
 from unittest import mock
 from ..._validators import (
-    _validate_schedule, check_continuous_task_exists, validate_continuouspatch_config_v1
+    _validate_schedule, validate_run_type, check_continuous_task_exists, validate_continuouspatch_config_v1
 )
 
 from azure.cli.core.azclierror import AzCLIError, InvalidArgumentValueError
@@ -34,6 +34,26 @@ class AcrCsscCommandsTests(unittest.TestCase):
 
         for timespan in test_cases:
             self.assertRaises(InvalidArgumentValueError, _validate_schedule, timespan)
+
+    def test_validate_run_type_valid(self):
+        test_cases = [
+            (True, False),
+            (False, True),
+            (False, False)
+        ]
+
+        for dryrun, run_immediately in test_cases:
+            with self.subTest(dryrun=dryrun, run_immediately=run_immediately):
+                validate_run_type(dryrun, run_immediately)
+
+    def test_validate_run_type_invalid(self):
+        test_cases = [
+            (True, True)
+        ]
+
+        for dryrun, run_immediately in test_cases:
+            with self.subTest(dryrun=dryrun, run_immediately=run_immediately):
+                self.assertRaises(InvalidArgumentValueError, validate_run_type, dryrun, run_immediately)
 
     @patch('azext_acrcssc._validators.cf_acr_tasks')
     def test_check_continuoustask_exists(self, mock_cf_acr_tasks):


### PR DESCRIPTION
Added validation to ensure that the `--dryrun` and `--run-immediately` options cannot be used together both during create and update.
Also added unit tests for this scenario to ensure the validation works as expected.

Bug - https://msazure.visualstudio.com/AzureContainerRegistry/_workitems/edit/31694592/?view=edit

After fix:
![image](https://github.com/user-attachments/assets/b5a2f868-8904-42ea-aa9e-acb561943d2f)
