### PR TITLE
fix(cssc): 31731403 Allow generate_logs poller to timeout

### DIFF
--- a/src/acrcssc/azext_acrcssc/_validators.py
+++ b/src/acrcssc/azext_acrcssc/_validators.py
@@ -139,7 +139,7 @@ def validate_inputs(schedule, config_file_path=None, dryrun=False, run_immediate
     if config_file_path is not None:
         validate_continuouspatch_config_v1(config_file_path)
     validate_run_type(dryrun, run_immediately)
-    
+
 
 def validate_run_type(dryrun, run_immediately):
     if dryrun and run_immediately:
@@ -174,7 +174,7 @@ def validate_continuous_patch_v1_image_limit(dryrun_log):
         result = re.sub(r'(?s)' + re.escape(pattern_postfix) + r'.*', pattern_postfix, result)
 
         raise InvalidArgumentValueError(error_msg=result)
-    
+
     if image_limit == 0:
         # when no matching images are found, we should relay the information to the user
         # extract everything between and including the target lines

--- a/src/acrcssc/azext_acrcssc/cssc.py
+++ b/src/acrcssc/azext_acrcssc/cssc.py
@@ -47,7 +47,7 @@ def _perform_continuous_patch_operation(cmd,
     # every time we perform a create or update operation, we need to validate for the number of images selected on the
     # configuration file. The way to do this is by silently running the dryrun operation. If the limit is exceeded, we
     # will not proceed with the operation.
-    dryrun_output = acr_cssc_dry_run(cmd, registry=registry, config_file_path=config, is_create=is_create, remove_internal_statements=not dryrun)    
+    dryrun_output = acr_cssc_dry_run(cmd, registry=registry, config_file_path=config, is_create=is_create, remove_internal_statements=not dryrun)
     if dryrun:
         print(dryrun_output)
     else:

--- a/src/acrcssc/azext_acrcssc/helper/_taskoperations.py
+++ b/src/acrcssc/azext_acrcssc/helper/_taskoperations.py
@@ -160,7 +160,8 @@ def delete_continuous_patch_v1(cmd, registry, dryrun):
         delete_oci_artifact_continuous_patch(cmd, registry, dryrun)
 
     if not cssc_tasks_exists:
-        logger.warning(f"{ERROR_MESSAGE_WORKFLOW_TASKS_DOES_NOT_EXIST}")        
+        logger.warning(f"{ERROR_MESSAGE_WORKFLOW_TASKS_DOES_NOT_EXIST}")
+
 
 def list_continuous_patch_v1(cmd, registry):
     logger.debug("Entering list_continuous_patch_v1")

--- a/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
@@ -416,15 +416,20 @@ class WorkflowTaskStatus:
                          run_id, registry_name, resource_group_name, e)
 
         if await_task_run:
-            polling_method = WorkflowLogPollingMethod(client,
-                                                      resource_group_name,
-                                                      registry_name,
-                                                      run_id)
-            result = LongRunningOperation(
-                cmd.cli_ctx,
-                progress_bar=IndeterminateProgressBar(cmd.cli_ctx, message=await_task_message)
-            )(polling_method)
-            logger.debug("Polling result: %s", result)
+            try:
+                polling_method = WorkflowLogPollingMethod(client,
+                                                        resource_group_name,
+                                                        registry_name,
+                                                        run_id)
+                result = LongRunningOperation(
+                    cmd.cli_ctx,
+                    progress_bar=IndeterminateProgressBar(cmd.cli_ctx, message=await_task_message),
+                    poller_done_interval_ms = 2000 # every poller call will do a call to the API
+                )(polling_method)
+                logger.debug("Polling result: %s", result)
+            except TimeoutError:
+                logger.debug("Timeout waiting for task run to complete, workflow task run ID: %s", run_id)
+                logger.debug("An attempt to retrieve the logs will be done, if there are any")
 
         blobClient = get_sdk(cmd.cli_ctx, ResourceType.DATA_STORAGE_BLOB, '_blob_client#BlobClient')
         return WorkflowTaskStatus._download_logs(blobClient.from_blob_url(log_file_sas))
@@ -450,6 +455,7 @@ class WorkflowTaskStatus:
 
     @staticmethod
     def remove_internal_acr_statements(blob_content):
+        logger.debug("Removing internal ACR statements from logs, blob content size: %s", len(blob_content))
         lines = blob_content.split("\n")
         starting_identifier = "DRY RUN mode enabled"
         terminating_identifier = "Total matches found"
@@ -517,6 +523,8 @@ class WorkflowTaskStatus:
         return list(taskruns)
 
 
+# this is a polling method that will poll the taskrun status until it is done
+# or the timeout is reached. It does not download the logs nor run the task
 class WorkflowLogPollingMethod(PollingMethod):
     def __init__(self, client, resource_group_name, registry_name, run_id):
         self.client = client
@@ -525,7 +533,7 @@ class WorkflowLogPollingMethod(PollingMethod):
         self.run_id = run_id
         self.run_status = TaskRunStatus.Running.value
         self.start_time = time.time()
-        self.timeout = 1
+        self.timeout = 10 * 60  # 10 minutes
 
     def initialize(self, client, initial_response, deserialization_callback):
         pass
@@ -534,35 +542,27 @@ class WorkflowLogPollingMethod(PollingMethod):
         return (time.time() - self.start_time) >= self.timeout
 
     def run(self):
-
-        while WorkflowTaskStatus.evaluate_task_run_nonterminal_state(self.run_status):
-            if self._timeout():
-                # if the taskrun is in a non-terminal state, we need to set it to timeout
-                logger.debug("Timeout waiting for task run to complete. Current status: %s", self.run_status)
-                self.run_status = TaskRunStatus.Timeout.value
-                break
-                # raise AzCLIError("Timeout waiting for task run to complete.")
-                
-            self.run_status = WorkflowTaskStatus.get_run_status_local(self.client,
-                                                                      self.resource_group_name,
-                                                                      self.registry_name,
-                                                                      self.run_id)
-
-            if WorkflowTaskStatus.evaluate_task_run_nonterminal_state(self.run_status):
-                logger.debug("Waiting for the task run to complete. Current status: %s", self.run_status)
-                time.sleep(2)
+        pass
 
     def status(self):
         return self.run_status
 
     def finished(self):
-        return not WorkflowTaskStatus.evaluate_task_run_nonterminal_state(self.status()) if not self._timeout() else True
+        if self._timeout():
+            raise TimeoutError("Timeout waiting for task run to complete")
+
+        self.run_status = WorkflowTaskStatus.get_run_status_local(self.client,
+                                                                    self.resource_group_name,
+                                                                    self.registry_name,
+                                                                    self.run_id)
+
+        return not WorkflowTaskStatus.evaluate_task_run_nonterminal_state(self.status())
 
     def done(self):
         return self.finished()
 
     def result(self):
-        return self.run_status
+        return self.status()
 
     def resource(self):
         return self.status()

--- a/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
@@ -523,10 +523,15 @@ class WorkflowLogPollingMethod(PollingMethod):
         self.registry_name = registry_name
         self.run_id = run_id
         self.run_status = TaskRunStatus.Running.value
+        self.start_time = time.time()
+        self.timeout = 10 * 60  # 60 minutes
 
     def initialize(self, client, initial_response, deserialization_callback):
         pass
 
+    def _timeout(self):
+        return (time.time() - self.start_time) >= self.timeout
+    
     def run(self):
 
         while WorkflowTaskStatus.evaluate_task_run_nonterminal_state(self.run_status):
@@ -534,6 +539,12 @@ class WorkflowLogPollingMethod(PollingMethod):
                                                                       self.resource_group_name,
                                                                       self.registry_name,
                                                                       self.run_id)
+            if self._timeout():
+                # if the taskrun is in a non-terminal state, we need to set it to timeout
+                logger.debug("Timeout waiting for task run to complete. Current status: %s", self.run_status)
+                self.run_status = TaskRunStatus.Timeout.value
+                raise AzCLIError("Timeout waiting for task run to complete.")
+            
             if WorkflowTaskStatus.evaluate_task_run_nonterminal_state(self.run_status):
                 logger.debug("Waiting for the task run to complete. Current status: %s", self.run_status)
                 time.sleep(2)
@@ -545,7 +556,7 @@ class WorkflowLogPollingMethod(PollingMethod):
                                                        self.run_id)
 
     def finished(self):
-        return not WorkflowTaskStatus.evaluate_task_run_nonterminal_state(self.status())
+        return not WorkflowTaskStatus.evaluate_task_run_nonterminal_state(self.status()) if not self._timeout() else True
 
     def done(self):
         return self.finished()

--- a/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
@@ -420,10 +420,11 @@ class WorkflowTaskStatus:
                                                       resource_group_name,
                                                       registry_name,
                                                       run_id)
-            LongRunningOperation(
+            result = LongRunningOperation(
                 cmd.cli_ctx,
                 progress_bar=IndeterminateProgressBar(cmd.cli_ctx, message=await_task_message)
             )(polling_method)
+            logger.debug("Polling result: %s", result)
 
         blobClient = get_sdk(cmd.cli_ctx, ResourceType.DATA_STORAGE_BLOB, '_blob_client#BlobClient')
         return WorkflowTaskStatus._download_logs(blobClient.from_blob_url(log_file_sas))
@@ -524,36 +525,35 @@ class WorkflowLogPollingMethod(PollingMethod):
         self.run_id = run_id
         self.run_status = TaskRunStatus.Running.value
         self.start_time = time.time()
-        self.timeout = 10 * 60  # 60 minutes
+        self.timeout = 1
 
     def initialize(self, client, initial_response, deserialization_callback):
         pass
 
     def _timeout(self):
         return (time.time() - self.start_time) >= self.timeout
-    
+
     def run(self):
 
         while WorkflowTaskStatus.evaluate_task_run_nonterminal_state(self.run_status):
-            self.run_status = WorkflowTaskStatus.get_run_status_local(self.client,
-                                                                      self.resource_group_name,
-                                                                      self.registry_name,
-                                                                      self.run_id)
             if self._timeout():
                 # if the taskrun is in a non-terminal state, we need to set it to timeout
                 logger.debug("Timeout waiting for task run to complete. Current status: %s", self.run_status)
                 self.run_status = TaskRunStatus.Timeout.value
-                raise AzCLIError("Timeout waiting for task run to complete.")
-            
+                break
+                # raise AzCLIError("Timeout waiting for task run to complete.")
+                
+            self.run_status = WorkflowTaskStatus.get_run_status_local(self.client,
+                                                                      self.resource_group_name,
+                                                                      self.registry_name,
+                                                                      self.run_id)
+
             if WorkflowTaskStatus.evaluate_task_run_nonterminal_state(self.run_status):
                 logger.debug("Waiting for the task run to complete. Current status: %s", self.run_status)
                 time.sleep(2)
 
     def status(self):
-        return WorkflowTaskStatus.get_run_status_local(self.client,
-                                                       self.resource_group_name,
-                                                       self.registry_name,
-                                                       self.run_id)
+        return self.run_status
 
     def finished(self):
         return not WorkflowTaskStatus.evaluate_task_run_nonterminal_state(self.status()) if not self._timeout() else True

--- a/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
@@ -426,7 +426,7 @@ class WorkflowTaskStatus:
                     progress_bar=IndeterminateProgressBar(cmd.cli_ctx, message=await_task_message),
                     poller_done_interval_ms = 2000 # every poller call will do a call to the API
                 )(polling_method)
-                logger.debug("Polling result: %s", result)
+                logger.debug("Task result: %s", result)
             except TimeoutError:
                 logger.debug("Timeout waiting for task run to complete, workflow task run ID: %s", run_id)
                 logger.debug("An attempt to retrieve the logs will be done, if there are any")

--- a/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
@@ -418,13 +418,13 @@ class WorkflowTaskStatus:
         if await_task_run:
             try:
                 polling_method = WorkflowLogPollingMethod(client,
-                                                        resource_group_name,
-                                                        registry_name,
-                                                        run_id)
+                                                          resource_group_name,
+                                                          registry_name,
+                                                          run_id)
                 result = LongRunningOperation(
                     cmd.cli_ctx,
                     progress_bar=IndeterminateProgressBar(cmd.cli_ctx, message=await_task_message),
-                    poller_done_interval_ms = 1500 # every poller call will do a call to the API
+                    poller_done_interval_ms=1500  # every poller call will do a call to the API
                 )(polling_method)
                 logger.debug("Task result: %s", result)
             except TimeoutError:
@@ -552,9 +552,9 @@ class WorkflowLogPollingMethod(PollingMethod):
             raise TimeoutError("Timeout waiting for task run to complete")
 
         self.run_status = WorkflowTaskStatus.get_run_status_local(self.client,
-                                                                    self.resource_group_name,
-                                                                    self.registry_name,
-                                                                    self.run_id)
+                                                                  self.resource_group_name,
+                                                                  self.registry_name,
+                                                                  self.run_id)
 
         return not WorkflowTaskStatus.evaluate_task_run_nonterminal_state(self.status())
 

--- a/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
@@ -424,7 +424,7 @@ class WorkflowTaskStatus:
                 result = LongRunningOperation(
                     cmd.cli_ctx,
                     progress_bar=IndeterminateProgressBar(cmd.cli_ctx, message=await_task_message),
-                    poller_done_interval_ms = 2000 # every poller call will do a call to the API
+                    poller_done_interval_ms = 1500 # every poller call will do a call to the API
                 )(polling_method)
                 logger.debug("Task result: %s", result)
             except TimeoutError:


### PR DESCRIPTION
To retrieve task logs class `WorkflowTaskStatus` uses a Poller to wait for a task run to finish before attempting to download the logs. This is only done during image limit check or when the `--dry-run` option is used during the `create` and `update` commands. Since this is a remote call there is a chance that we never get a response.

This PR adds a 10-minute timeout to the Poller. In case the timeout is reached, the required message is logged, and the attempt will be done to retrieve the logs if there are any to allow the operation to continue.

In case of a timeout during `create` or `update` the command will not block in case the image limit check could not be performed, to allow for a better user experience. In case the image limit is reached, the user will be informed via the trigger task that will perform the check every time it runs.