### PR TITLE
fix(cssc): 31646926 fix 'list' command filtering by '--run-status'

### DIFF
--- a/src/acrcssc/azext_acrcssc/helper/_taskoperations.py
+++ b/src/acrcssc/azext_acrcssc/helper/_taskoperations.py
@@ -350,10 +350,13 @@ def _retrieve_logs_for_image(cmd, registry, resource_group_name, schedule, workf
     progress_indicator = IndeterminateProgressBar(cmd.cli_ctx, message="Retrieving logs for images")
     progress_indicator.begin()
 
-    image_status = WorkflowTaskStatus.from_taskrun(cmd, acr_task_run_client, registry, scan_taskruns, patch_taskruns, progress_indicator=progress_indicator)
-    if workflow_status:
-        filtered_image_status = [image for image in image_status if image["patch_status"] == workflow_status or image["scan_status"] == workflow_status]
-        image_status = filtered_image_status
+    image_status = WorkflowTaskStatus.from_taskrun(cmd,
+                                                   acr_task_run_client,
+                                                   registry,
+                                                   scan_taskruns,
+                                                   patch_taskruns,
+                                                   progress_indicator=progress_indicator,
+                                                   workflow_status_filter=workflow_status)
 
     end_time = time.time()
     execution_time = end_time - start_time

--- a/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
@@ -330,9 +330,10 @@ class WorkflowTaskStatus:
         if not workflow_status_filter:
             return workflows
 
-        # SKIPPED is a special case, because it means that the patch task does not exist, but the scan task
-        # succeeded. Another special case that is not explicit here is SUCCEEDED, which will include both 
-        # scan and patch tasks that succeeded, or the scan task succeeded and the patch task is skipped
+        # SKIPPED is a special case, because it means that the patch task does not exist,
+        # but the scan task succeeded. Another special case that is not explicit here is SUCCEEDED,
+        # which will include both scan and patch tasks that succeeded, or the scan task succeeded
+        # and the patch task is skipped
         if workflow_status_filter == WorkflowTaskState.SKIPPED.value:
             filtered_workflow = {key: workflow
                                  for key, workflow in workflows.items()
@@ -340,9 +341,10 @@ class WorkflowTaskStatus:
                                  workflow.patch_status() == WorkflowTaskState.SKIPPED.value}
             return filtered_workflow
 
-        filtered_workflow = {key: workflow
-                                for key, workflow in workflows.items()
-                                if workflow.status() == workflow_status_filter}
+        filtered_workflow = {
+            key: workflow
+            for key, workflow in workflows.items()
+            if workflow.status() == workflow_status_filter}
         return filtered_workflow
 
     def get_status(self):

--- a/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
@@ -255,7 +255,7 @@ class WorkflowTaskStatus:
             concurrent.futures.wait(futures)
 
     @staticmethod
-    def from_taskrun(cmd, taskrun_client, registry, scan_taskruns, patch_taskruns, progress_indicator=None):
+    def from_taskrun(cmd, taskrun_client, registry, scan_taskruns, patch_taskruns, progress_indicator=None, workflow_status_filter=None):
         WorkflowTaskStatus._retrieve_all_tasklogs(cmd, taskrun_client, registry, scan_taskruns, progress_indicator)
         all_status = {}
 
@@ -312,6 +312,10 @@ class WorkflowTaskStatus:
             WorkflowTaskStatus._retrieve_all_tasklogs(cmd, taskrun_client, registry, taskrunList, progress_indicator)
             for workflow_status in failed_patch_tasklog_retrieval:
                 workflow_status.patch_logs = workflow_status.patch_task.task_log_result
+
+        if workflow_status_filter:
+            filtered_workflow = {key: workflow for key, workflow in all_status.items() if workflow.status() == workflow_status_filter}
+            all_status = filtered_workflow
 
         return [status.get_status() for status in all_status.values()]
 

--- a/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
@@ -255,7 +255,13 @@ class WorkflowTaskStatus:
             concurrent.futures.wait(futures)
 
     @staticmethod
-    def from_taskrun(cmd, taskrun_client, registry, scan_taskruns, patch_taskruns, progress_indicator=None, workflow_status_filter=None):
+    def from_taskrun(cmd,
+                     taskrun_client,
+                     registry,
+                     scan_taskruns,
+                     patch_taskruns,
+                     progress_indicator=None,
+                     workflow_status_filter=None):
         WorkflowTaskStatus._retrieve_all_tasklogs(cmd, taskrun_client, registry, scan_taskruns, progress_indicator)
         all_status = {}
 
@@ -314,8 +320,8 @@ class WorkflowTaskStatus:
                 workflow_status.patch_logs = workflow_status.patch_task.task_log_result
 
         if workflow_status_filter:
-            filtered_workflow = {key: workflow 
-                                 for key, workflow in all_status.items() 
+            filtered_workflow = {key: workflow
+                                 for key, workflow in all_status.items()
                                  if workflow.status() == workflow_status_filter}
             all_status = filtered_workflow
 

--- a/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
@@ -116,6 +116,13 @@ class WorkflowTaskStatus:
             return self.scan_status()
 
         return self.patch_status()
+    
+    def workflow_status(self, filter_status):
+        # this is the workflow status, which is the status of the scan task and the patch task
+        # if both exist, we return the patch status, otherwise we return the scan status
+        if self.patch_task is None: # use _workflow_status_to_task_status to filter the status on the tasks
+            return any() self.scan_task
+        return self.patch_status()
 
     # this extracts the image from the copacetic task logs, using this when we only have a repository
     # name and a wildcard tag

--- a/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
@@ -116,13 +116,6 @@ class WorkflowTaskStatus:
             return self.scan_status()
 
         return self.patch_status()
-    
-    def workflow_status(self, filter_status):
-        # this is the workflow status, which is the status of the scan task and the patch task
-        # if both exist, we return the patch status, otherwise we return the scan status
-        if self.patch_task is None: # use _workflow_status_to_task_status to filter the status on the tasks
-            return any() self.scan_task
-        return self.patch_status()
 
     # this extracts the image from the copacetic task logs, using this when we only have a repository
     # name and a wildcard tag
@@ -321,7 +314,9 @@ class WorkflowTaskStatus:
                 workflow_status.patch_logs = workflow_status.patch_task.task_log_result
 
         if workflow_status_filter:
-            filtered_workflow = {key: workflow for key, workflow in all_status.items() if workflow.status() == workflow_status_filter}
+            filtered_workflow = {key: workflow 
+                                 for key, workflow in all_status.items() 
+                                 if workflow.status() == workflow_status_filter}
             all_status = filtered_workflow
 
         return [status.get_status() for status in all_status.values()]

--- a/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/helper/_workflow_status.py
@@ -319,13 +319,31 @@ class WorkflowTaskStatus:
             for workflow_status in failed_patch_tasklog_retrieval:
                 workflow_status.patch_logs = workflow_status.patch_task.task_log_result
 
-        if workflow_status_filter:
-            filtered_workflow = {key: workflow
-                                 for key, workflow in all_status.items()
-                                 if workflow.status() == workflow_status_filter}
-            all_status = filtered_workflow
+        return [status.get_status()
+                for status in WorkflowTaskStatus._filter_taskruns(all_status, workflow_status_filter).values()]
 
-        return [status.get_status() for status in all_status.values()]
+    @staticmethod
+    def _filter_taskruns(workflows, workflow_status_filter=None):
+        if not workflows:
+            return {}
+
+        if not workflow_status_filter:
+            return workflows
+
+        # SKIPPED is a special case, because it means that the patch task does not exist, but the scan task
+        # succeeded. Another special case that is not explicit here is SUCCEEDED, which will include both 
+        # scan and patch tasks that succeeded, or the scan task succeeded and the patch task is skipped
+        if workflow_status_filter == WorkflowTaskState.SKIPPED.value:
+            filtered_workflow = {key: workflow
+                                 for key, workflow in workflows.items()
+                                 if workflow.scan_status() == WorkflowTaskState.SUCCEEDED.value and
+                                 workflow.patch_status() == WorkflowTaskState.SKIPPED.value}
+            return filtered_workflow
+
+        filtered_workflow = {key: workflow
+                                for key, workflow in workflows.items()
+                                if workflow.status() == workflow_status_filter}
+        return filtered_workflow
 
     def get_status(self):
         scan_status = self.scan_status()

--- a/src/acrcssc/azext_acrcssc/tests/latest/test_cssc.py
+++ b/src/acrcssc/azext_acrcssc/tests/latest/test_cssc.py
@@ -22,7 +22,6 @@ class AcrcsscTest(unittest.TestCase):
     def test_create_acrcssc(self, mock_perform_continuous_patch_operation):
         create_acrcssc(self.cmd, "mockrg", self.registry.name, "continuouspatchv1", "mockconfig", "1d", False, False)
         mock_perform_continuous_patch_operation.assert_called_once_with(self.cmd, "mockrg", self.registry.name, "mockconfig", "1d", False, False, is_create=True)
-        self.assertTrue(False)
 
     @mock.patch("azext_acrcssc.cssc._perform_continuous_patch_operation")
     def test_update_acrcssc(self, mock_perform_continuous_patch_operation):

--- a/src/acrcssc/azext_acrcssc/tests/latest/test_cssc.py
+++ b/src/acrcssc/azext_acrcssc/tests/latest/test_cssc.py
@@ -22,6 +22,7 @@ class AcrcsscTest(unittest.TestCase):
     def test_create_acrcssc(self, mock_perform_continuous_patch_operation):
         create_acrcssc(self.cmd, "mockrg", self.registry.name, "continuouspatchv1", "mockconfig", "1d", False, False)
         mock_perform_continuous_patch_operation.assert_called_once_with(self.cmd, "mockrg", self.registry.name, "mockconfig", "1d", False, False, is_create=True)
+        self.assertTrue(False)
 
     @mock.patch("azext_acrcssc.cssc._perform_continuous_patch_operation")
     def test_update_acrcssc(self, mock_perform_continuous_patch_operation):

--- a/src/acrcssc/azext_acrcssc/tests/latest/test_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/tests/latest/test_workflow_status.py
@@ -159,11 +159,11 @@ Error: unsupported osType azurelinux specified"""
         self.assertTrue(result[0]["patch_status"] == WorkflowTaskState.SUCCEEDED.value)
 
         # Test with mixed scan and patch tasks status
-        patch_taskruns = [self._generate_test_taskrun(True, status=TaskRunStatus.Succeeded.value, tag="tag0"),
-                          self._generate_test_taskrun(True, status=TaskRunStatus.Canceled.value, tag="tag1"),
-                          self._generate_test_taskrun(True, status=TaskRunStatus.Queued.value, tag="tag2"),
-                          self._generate_test_taskrun(True, status=TaskRunStatus.Running.value, tag="tag3"),
-                          self._generate_test_taskrun(True, status=TaskRunStatus.Failed.value, tag="tag4")]
+        patch_taskruns = [self._generate_test_taskrun(False, status=TaskRunStatus.Succeeded.value, tag="tag0"),
+                          self._generate_test_taskrun(False, status=TaskRunStatus.Canceled.value, tag="tag1"),
+                          self._generate_test_taskrun(False, status=TaskRunStatus.Queued.value, tag="tag2"),
+                          self._generate_test_taskrun(False, status=TaskRunStatus.Running.value, tag="tag3"),
+                          self._generate_test_taskrun(False, status=TaskRunStatus.Failed.value, tag="tag4")]
 
         scan_taskruns = [self._generate_test_taskrun(True, patch_taskid_in_scan=patch_taskruns[0].run_id, tag="tag0"),
                          self._generate_test_taskrun(True, patch_taskid_in_scan=patch_taskruns[1].run_id, tag="tag1"),
@@ -201,18 +201,18 @@ Error: unsupported osType azurelinux specified"""
         cmd.cli_ctx = DummyCli()
         taskrun_client = MagicMock()
         registry = MagicMock()
-        scan_taskruns = [self._generate_test_taskrun(True, repository="mock1"), self._generate_test_taskrun(True, repository="mock2"), self._generate_test_taskrun(True, repository="mock3")]
+        scan_taskruns = []
         patch_taskruns = []
 
         mock_retrieve_all_tasklogs.return_value = scan_taskruns
         mock_get_missing_taskrun.return_value = None
         
          # Test with mixed scan and patch tasks status
-        patch_taskruns = [self._generate_test_taskrun(True, status=TaskRunStatus.Succeeded.value, tag="tag0"),
-                          self._generate_test_taskrun(True, status=TaskRunStatus.Canceled.value, tag="tag1"),
-                          self._generate_test_taskrun(True, status=TaskRunStatus.Queued.value, tag="tag2"),
-                          self._generate_test_taskrun(True, status=TaskRunStatus.Running.value, tag="tag3"),
-                          self._generate_test_taskrun(True, status=TaskRunStatus.Failed.value, tag="tag4")]
+        patch_taskruns = [self._generate_test_taskrun(False, status=TaskRunStatus.Succeeded.value, tag="tag0"),
+                          self._generate_test_taskrun(False, status=TaskRunStatus.Canceled.value, tag="tag1"),
+                          self._generate_test_taskrun(False, status=TaskRunStatus.Queued.value, tag="tag2"),
+                          self._generate_test_taskrun(False, status=TaskRunStatus.Running.value, tag="tag3"),
+                          self._generate_test_taskrun(False, status=TaskRunStatus.Failed.value, tag="tag4")]
 
         scan_taskruns = [self._generate_test_taskrun(True, patch_taskid_in_scan=patch_taskruns[0].run_id, tag="tag0"),
                          self._generate_test_taskrun(True, patch_taskid_in_scan=patch_taskruns[1].run_id, tag="tag1"),
@@ -222,7 +222,8 @@ Error: unsupported osType azurelinux specified"""
                          self._generate_test_taskrun(True, status=TaskRunStatus.Failed.value, tag="tag5"),
                          self._generate_test_taskrun(True, status=TaskRunStatus.Canceled.value, tag="tag6"),
                          self._generate_test_taskrun(True, status=TaskRunStatus.Queued.value, tag="tag7"),
-                         self._generate_test_taskrun(True, status=TaskRunStatus.Running.value, tag="tag8"),]
+                         self._generate_test_taskrun(True, status=TaskRunStatus.Running.value, tag="tag8"),
+                         self._generate_test_taskrun(True, status=TaskRunStatus.Succeeded.value, tag="tag9")]
         
         result = WorkflowTaskStatus.from_taskrun(cmd,
                                                  taskrun_client,

--- a/src/acrcssc/azext_acrcssc/tests/latest/test_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/tests/latest/test_workflow_status.py
@@ -28,7 +28,7 @@ class TestWorkflowTaskStatus(unittest.TestCase):
     def test_image(self):
         self.assertEqual(self.workflow_task_status.image(), "repository:tag")
 
-    def test__task_status_to_workflow_status(self):
+    def test_task_status_to_workflow_status(self):
         from azext_acrcssc.helper._constants import TaskRunStatus
         task = mock.MagicMock()
         task.status = TaskRunStatus.Succeeded.value
@@ -192,6 +192,92 @@ Error: unsupported osType azurelinux specified"""
         self.assertTrue(all(True if workflow["scan_status"] != TaskRunStatus.Failed.value or "scan_error_reason" in workflow else False for workflow in result))
         # test that a successful patch has a patched image reference
         self.assertTrue(all(True if workflow["patch_status"] != TaskRunStatus.Succeeded.value or not workflow["last_patched_image"].startswith("---") else False for workflow in result))
+
+
+    @mock.patch('azext_acrcssc.helper._workflow_status.WorkflowTaskStatus._get_missing_taskrun')
+    @mock.patch('azext_acrcssc.helper._workflow_status.WorkflowTaskStatus._retrieve_all_tasklogs')
+    def test_from_taskrun_with_filter(self, mock_retrieve_all_tasklogs, mock_get_missing_taskrun):
+        cmd = mock.MagicMock()
+        cmd.cli_ctx = DummyCli()
+        taskrun_client = MagicMock()
+        registry = MagicMock()
+        scan_taskruns = [self._generate_test_taskrun(True, repository="mock1"), self._generate_test_taskrun(True, repository="mock2"), self._generate_test_taskrun(True, repository="mock3")]
+        patch_taskruns = []
+
+        mock_retrieve_all_tasklogs.return_value = scan_taskruns
+        mock_get_missing_taskrun.return_value = None
+        
+         # Test with mixed scan and patch tasks status
+        patch_taskruns = [self._generate_test_taskrun(True, status=TaskRunStatus.Succeeded.value, tag="tag0"),
+                          self._generate_test_taskrun(True, status=TaskRunStatus.Canceled.value, tag="tag1"),
+                          self._generate_test_taskrun(True, status=TaskRunStatus.Queued.value, tag="tag2"),
+                          self._generate_test_taskrun(True, status=TaskRunStatus.Running.value, tag="tag3"),
+                          self._generate_test_taskrun(True, status=TaskRunStatus.Failed.value, tag="tag4")]
+
+        scan_taskruns = [self._generate_test_taskrun(True, patch_taskid_in_scan=patch_taskruns[0].run_id, tag="tag0"),
+                         self._generate_test_taskrun(True, patch_taskid_in_scan=patch_taskruns[1].run_id, tag="tag1"),
+                         self._generate_test_taskrun(True, patch_taskid_in_scan=patch_taskruns[2].run_id, tag="tag2"),
+                         self._generate_test_taskrun(True, patch_taskid_in_scan=patch_taskruns[3].run_id, tag="tag3"),
+                         self._generate_test_taskrun(True, patch_taskid_in_scan=patch_taskruns[4].run_id, tag="tag4"),
+                         self._generate_test_taskrun(True, status=TaskRunStatus.Failed.value, tag="tag5"),
+                         self._generate_test_taskrun(True, status=TaskRunStatus.Canceled.value, tag="tag6"),
+                         self._generate_test_taskrun(True, status=TaskRunStatus.Queued.value, tag="tag7"),
+                         self._generate_test_taskrun(True, status=TaskRunStatus.Running.value, tag="tag8"),]
+        
+        result = WorkflowTaskStatus.from_taskrun(cmd,
+                                                 taskrun_client,
+                                                 registry,
+                                                 scan_taskruns,
+                                                 patch_taskruns,
+                                                 workflow_status_filter=WorkflowTaskState.SUCCEEDED.value)
+        self.assertTrue(all(workflow["scan_status"] == WorkflowTaskState.SUCCEEDED.value 
+                            for workflow in result))
+        self.assertTrue(all(workflow["patch_status"] == WorkflowTaskState.SUCCEEDED.value or 
+                            workflow["patch_status"] == WorkflowTaskState.SKIPPED.value
+                            for workflow in result))
+
+        result = WorkflowTaskStatus.from_taskrun(cmd,
+                                                 taskrun_client,
+                                                 registry,
+                                                 scan_taskruns,
+                                                 patch_taskruns,
+                                                 workflow_status_filter=WorkflowTaskState.FAILED.value)
+        self.assertTrue(all(workflow["scan_status"] == WorkflowTaskState.FAILED.value or 
+                            workflow["patch_status"] == WorkflowTaskState.FAILED.value 
+                            for workflow in result))
+        
+        result = WorkflowTaskStatus.from_taskrun(cmd,
+                                                 taskrun_client,
+                                                 registry,
+                                                 scan_taskruns,
+                                                 patch_taskruns,
+                                                 workflow_status_filter=WorkflowTaskState.RUNNING.value)
+        self.assertTrue(all(workflow["scan_status"] == WorkflowTaskState.RUNNING.value or
+                            workflow["patch_status"] == WorkflowTaskState.RUNNING.value or
+                            workflow["scan_status"] == WorkflowTaskState.QUEUED.value or
+                            workflow["patch_status"] == WorkflowTaskState.QUEUED.value
+                            for workflow in result))
+        
+        result = WorkflowTaskStatus.from_taskrun(cmd,
+                                                 taskrun_client,
+                                                 registry,
+                                                 scan_taskruns,
+                                                 patch_taskruns,
+                                                 workflow_status_filter=WorkflowTaskState.CANCELED.value)
+        self.assertTrue(all(workflow["scan_status"] == WorkflowTaskState.CANCELED.value or
+                            workflow["patch_status"] == WorkflowTaskState.CANCELED.value
+                            for workflow in result))
+        
+        result = WorkflowTaskStatus.from_taskrun(cmd,
+                                                 taskrun_client,
+                                                 registry,
+                                                 scan_taskruns,
+                                                 patch_taskruns,
+                                                 workflow_status_filter=WorkflowTaskState.SKIPPED.value)
+        self.assertTrue(all(workflow["scan_status"] == WorkflowTaskState.SUCCEEDED.value and
+                            workflow["patch_status"] == WorkflowTaskState.SKIPPED.value
+                            for workflow in result))
+
 
     # generate a random scan or patch taskrun with the desired properties
     def _generate_test_taskrun(self, scan_task=True, status=TaskRunStatus.Succeeded.value, repository="mock-repo", tag="mock-tag", patch_taskid_in_scan=""):

--- a/src/acrcssc/azext_acrcssc/tests/latest/test_workflow_status.py
+++ b/src/acrcssc/azext_acrcssc/tests/latest/test_workflow_status.py
@@ -231,6 +231,7 @@ Error: unsupported osType azurelinux specified"""
                                                  scan_taskruns,
                                                  patch_taskruns,
                                                  workflow_status_filter=WorkflowTaskState.SUCCEEDED.value)
+        self.assertTrue(len(result) > 0)
         self.assertTrue(all(workflow["scan_status"] == WorkflowTaskState.SUCCEEDED.value 
                             for workflow in result))
         self.assertTrue(all(workflow["patch_status"] == WorkflowTaskState.SUCCEEDED.value or 
@@ -243,6 +244,7 @@ Error: unsupported osType azurelinux specified"""
                                                  scan_taskruns,
                                                  patch_taskruns,
                                                  workflow_status_filter=WorkflowTaskState.FAILED.value)
+        self.assertTrue(len(result) > 0)
         self.assertTrue(all(workflow["scan_status"] == WorkflowTaskState.FAILED.value or 
                             workflow["patch_status"] == WorkflowTaskState.FAILED.value 
                             for workflow in result))
@@ -253,6 +255,7 @@ Error: unsupported osType azurelinux specified"""
                                                  scan_taskruns,
                                                  patch_taskruns,
                                                  workflow_status_filter=WorkflowTaskState.RUNNING.value)
+        self.assertTrue(len(result) > 0)
         self.assertTrue(all(workflow["scan_status"] == WorkflowTaskState.RUNNING.value or
                             workflow["patch_status"] == WorkflowTaskState.RUNNING.value or
                             workflow["scan_status"] == WorkflowTaskState.QUEUED.value or
@@ -265,6 +268,7 @@ Error: unsupported osType azurelinux specified"""
                                                  scan_taskruns,
                                                  patch_taskruns,
                                                  workflow_status_filter=WorkflowTaskState.CANCELED.value)
+        self.assertTrue(len(result) > 0)
         self.assertTrue(all(workflow["scan_status"] == WorkflowTaskState.CANCELED.value or
                             workflow["patch_status"] == WorkflowTaskState.CANCELED.value
                             for workflow in result))
@@ -275,6 +279,7 @@ Error: unsupported osType azurelinux specified"""
                                                  scan_taskruns,
                                                  patch_taskruns,
                                                  workflow_status_filter=WorkflowTaskState.SKIPPED.value)
+        self.assertTrue(len(result) > 0)
         self.assertTrue(all(workflow["scan_status"] == WorkflowTaskState.SUCCEEDED.value and
                             workflow["patch_status"] == WorkflowTaskState.SKIPPED.value
                             for workflow in result))


### PR DESCRIPTION
Fix filtering on the `list` command by `--run-status` to make it correct once again.
Now the `--run-status` will filter the image status depending on the final status of both the scan and patch instead of only one of them. Meaning that for an image to be marked as `FAILED` scan or patch have to be `FAILED`, for an image to be marked as `SUCCEEDED` both scan and patch have to be `SUCCEEDED` or `SKIPPED` as that is treated as a successful execution, and for an image to be marked as `SKIPPED` the scan has to be `SUCCEEDED` and the patch has to be `SKIPPED`.

This PR also includes a unit test to catch issues with the filtering.

In addition, includes fixes for unit tests that are run without azure credentials, adding the required mocks to avoid that dependency.

Some example output:
```
$ az acr supply-chain workflow list --run-status succeeded ...
Listing images that have been scanned and/or patched in the last 2 days
Total images: 17
[
  {
    "image": "citest:powershell_lts-7.2-ubuntu-focal",
    "last_patched_image": "citest:powershell_lts-7.2-ubuntu-focal-1",
    "patch_date": "---Not Available---",
    "patch_skipped_reason": "no vulnerability found in the image citest:powershell_lts-7.2-ubuntu-focal-1",
    "patch_status": "Skipped",
    "patch_task_ID": "---Not Available---",
    "scan_date": "2025-03-20T22:58:29.101178+00:00",
    "scan_status": "Succeeded",
    "scan_task_ID": "dt3h3",
    "workflow_type": "continuouspatchv1"
  },
  {
    "image": "import:ubuntu-jammy-20240111",
    "last_patched_image": "import:ubuntu-jammy-20240111-6",
    "patch_date": "---Not Available---",
    "patch_skipped_reason": "no vulnerability found in the image import:ubuntu-jammy-20240111-6\r",
    "patch_status": "Skipped",
    "patch_task_ID": "---Not Available---",
    "scan_date": "2025-03-20T22:58:26.024742+00:00",
    "scan_status": "Succeeded",
    "scan_task_ID": "dt3h2",
    "workflow_type": "continuouspatchv1"
  },
  {
    "image": "import:pytorch-2.2.2-1-azl3.0.20240727-amd64",
    "last_patched_image": "import:pytorch-2.2.2-1-azl3.0.20240727-amd64-5",
    "patch_date": "2025-03-20T22:59:10.231822+00:00",
    "patch_status": "Succeeded",
    "patch_task_ID": "dt3h8",
    "scan_date": "2025-03-20T22:58:21.199712+00:00",
    "scan_status": "Succeeded",
    "scan_task_ID": "dt3h1",
    "workflow_type": "continuouspatchv1"
  },
  {
    "image": "import:openmpi-4.1.5-1-azl3.0.20240727-amd64",
    "last_patched_image": "import:openmpi-4.1.5-1-azl3.0.20240727-amd64-6",
    "patch_date": "2025-03-20T22:58:54.001933+00:00",
    "patch_status": "Succeeded",
    "patch_task_ID": "dt3h6",
    "scan_date": "2025-03-20T22:58:18.284315+00:00",
    "scan_status": "Succeeded",
    "scan_task_ID": "dt3h0",
    "workflow_type": "continuouspatchv1"
  },
...
```

```
$ az acr supply-chain workflow list --run-status skipped ...
Listing images that have been scanned and/or patched in the last 2 days
Total images: 14
[
  {
    "image": "citest:powershell_ubuntu-22.04",
    "last_patched_image": "citest:powershell_ubuntu-22.04-1",
    "patch_date": "---Not Available---",
    "patch_skipped_reason": "no vulnerability found in the image citest:powershell_ubuntu-22.04-1",
    "patch_status": "Skipped",
    "patch_task_ID": "---Not Available---",
    "scan_date": "2025-03-20T22:59:05.572797+00:00",
    "scan_status": "Succeeded",
    "scan_task_ID": "dt3h7",
    "workflow_type": "continuouspatchv1"
  },
  {
    "image": "citest:powershell_ubuntu-20.04",
    "last_patched_image": "citest:powershell_ubuntu-20.04-1",
    "patch_date": "---Not Available---",
    "patch_skipped_reason": "no vulnerability found in the image citest:powershell_ubuntu-20.04-1",
    "patch_status": "Skipped",
    "patch_task_ID": "---Not Available---",
    "scan_date": "2025-03-20T22:58:32.219472+00:00",
    "scan_status": "Succeeded",
    "scan_task_ID": "dt3h4",
    "workflow_type": "continuouspatchv1"
  },
...
```

```
$ az acr supply-chain workflow list --run-status failed ...
Listing images that have been scanned and/or patched in the last 2 days
Total images: 4
[
  {
    "image": "import:dotnet-samples-aspnetapp-jammy-chiseled-composite-amd64",
    "last_patched_image": "---No patch image available---",
    "patch_date": "2025-03-20T22:57:59.380189+00:00",
    "patch_error_reason": "ERROR: process \"apt-get update\" did not complete successfully: exit code: 1\nError: failed during run, err: exit status 1\r\nError: process \"apt-get update\" did not complete successfully: exit code: 1",
    "patch_status": "Failed",
    "patch_task_ID": "dt3gu",
    "scan_date": "2025-03-20T22:57:19.033179+00:00",
    "scan_status": "Succeeded",
    "scan_task_ID": "dt3gn",
    "workflow_type": "continuouspatchv1"
  },
  {
    "image": "python-cache:3.12.3-2-azl3.0.20240824-amd64",
    "last_patched_image": "---No patch image available---",
    "patch_date": "2025-03-20T22:57:48.215233+00:00",
    "patch_error_reason": "Error: failed during run, err: exit status 1\r\nerror parsing HTTP 429 response body: unexpected end of JSON input: \"\"",
    "patch_status": "Failed",
    "patch_task_ID": "dt3gs",
    "scan_date": "2025-03-20T22:57:12.966699+00:00",
    "scan_status": "Succeeded",
    "scan_task_ID": "dt3gk",
    "workflow_type": "continuouspatchv1"
  },
...
```