### PR TITLE
fix(cssc): 31670352 Upgrade oras-py package to use new auth flow 2/n

### DIFF
--- a/src/acrcssc/azext_acrcssc/helper/_ociartifactoperations.py
+++ b/src/acrcssc/azext_acrcssc/helper/_ociartifactoperations.py
@@ -126,9 +126,9 @@ def _oras_client(registry):
     try:
         token = _get_acr_token(registry.name, subscription)
         client = OrasClient(hostname=str.lower(registry.login_server), auth_backend="token")
-        wut = client.login(BEARER_TOKEN_USERNAME, token)
+        response = client.login(BEARER_TOKEN_USERNAME, token)
 
-        logger.debug(f"Login to ACR {registry.name} completed successfully: {wut}")
+        logger.debug(f"Login to ACR {registry.name} completed successfully: {response}")
     except Exception as exception:
         raise AzCLIError(f"Failed to login to Artifact Store ACR {registry.name}: {exception}")
 

--- a/src/acrcssc/azext_acrcssc/helper/_ociartifactoperations.py
+++ b/src/acrcssc/azext_acrcssc/helper/_ociartifactoperations.py
@@ -126,9 +126,8 @@ def _oras_client(registry):
     try:
         token = _get_acr_token(registry.name, subscription)
         client = OrasClient(hostname=str.lower(registry.login_server), auth_backend="token")
-        response = client.login(BEARER_TOKEN_USERNAME, token)
-
-        logger.debug(f"Login to ACR {registry.name} completed successfully: {response}")
+        client.login(BEARER_TOKEN_USERNAME, token)
+        logger.debug(f"Login to ACR {registry.name} completed successfully.")
     except Exception as exception:
         raise AzCLIError(f"Failed to login to Artifact Store ACR {registry.name}: {exception}")
 

--- a/src/acrcssc/azext_acrcssc/helper/_ociartifactoperations.py
+++ b/src/acrcssc/azext_acrcssc/helper/_ociartifactoperations.py
@@ -84,7 +84,7 @@ def get_oci_artifact_continuous_patch(cmd, registry):
         oci_target_name = f"{CSSC_WORKFLOW_POLICY_REPOSITORY}/{CONTINUOUSPATCH_OCI_ARTIFACT_CONFIG}:{CONTINUOUSPATCH_OCI_ARTIFACT_CONFIG_TAG_V1}"
 
         oci_artifacts = oras_client.pull(target=oci_target_name,
-                                         stream=True)
+                                         overwrite=True)
         trigger_task = get_task(cmd, registry, CONTINUOUSPATCH_TASK_SCANREGISTRY_NAME)
         file_name = oci_artifacts[0]
         config = ContinuousPatchConfig().from_file(file_name, trigger_task)
@@ -125,8 +125,10 @@ def _oras_client(registry):
 
     try:
         token = _get_acr_token(registry.name, subscription)
-        client = OrasClient(hostname=str.lower(registry.login_server))
-        client.login(BEARER_TOKEN_USERNAME, token)
+        client = OrasClient(hostname=str.lower(registry.login_server), auth_backend="token")
+        wut = client.login(BEARER_TOKEN_USERNAME, token)
+
+        logger.debug(f"Login to ACR {registry.name} completed successfully: {wut}")
     except Exception as exception:
         raise AzCLIError(f"Failed to login to Artifact Store ACR {registry.name}: {exception}")
 

--- a/src/acrcssc/setup.py
+++ b/src/acrcssc/setup.py
@@ -31,7 +31,7 @@ CLASSIFIERS = [
 ]
 
 # TODO: Add any additional SDK dependencies here
-DEPENDENCIES = ["oras~=0.1.19", "croniter~=3.0.0"]
+DEPENDENCIES = ["oras~=0.2.25", "croniter~=3.0.0"]
 
 with open('README.rst', 'r', encoding='utf-8') as f:
     README = f.read()


### PR DESCRIPTION
This change is a continuation of the changes in [PR 39](https://github.com/AzureCR/azure-cli-extensions/pull/39)
Updates the `oras` packages to 0.2.25 to use a more recent version of the package to avoid the "empty token" error when authenticating to the registry.