### PR TITLE
fix(cssc): 31250186 address comments on versioning #8690

### DIFF
--- a/src/acrcssc/HISTORY.rst
+++ b/src/acrcssc/HISTORY.rst
@@ -3,7 +3,7 @@
 Release History
 ===============
 
-1.1.1
+1.0.0b1
 ++++++
 * Release for Public Preview
 * Added `list`and `cancel-run` commands for workflows
@@ -11,6 +11,6 @@ Release History
 * `cancel-run` command allows to canceling all running scan and patch tasks
 
 
-1.1.0
+0.1.0b1
 ++++++
 * Initial release for Private Preview

--- a/src/acrcssc/azext_acrcssc/_params.py
+++ b/src/acrcssc/azext_acrcssc/_params.py
@@ -6,7 +6,11 @@
 from azure.cli.command_modules.acr._constants import REGISTRY_RESOURCE_TYPE
 from azure.cli.command_modules.acr._validators import validate_registry_name
 from azure.cli.core import AzCommandsLoader
-from azure.cli.core.commands.parameters import (get_resource_name_completion_list, get_three_state_flag, get_enum_type)
+from azure.cli.core.commands.parameters import (
+    get_resource_name_completion_list,
+    get_three_state_flag, get_enum_type,
+    resource_group_name_type
+)
 from .helper._constants import CONTINUOUSPATCH_SCHEDULE_MAX_DAYS
 
 
@@ -15,7 +19,7 @@ def load_arguments(self: AzCommandsLoader, _):
     from .helper._workflow_status import WorkflowTaskState
 
     with self.argument_context("acr supply-chain workflow") as c:
-        c.argument('resource_group', options_list=['--resource-group', '-g'], help='Name of resource group. You can configure the default group using `az configure --defaults group=<name>`', completer=get_resource_name_completion_list(REGISTRY_RESOURCE_TYPE))
+        c.argument('resource_group', resource_group_name_type, completer=get_resource_name_completion_list(REGISTRY_RESOURCE_TYPE))
         c.argument('registry_name', options_list=['--registry', '-r'], help='The name of the container registry. It should be specified in lower case. You can configure the default registry name using `az configure --defaults acr=<registry name>`', completer=get_resource_name_completion_list(REGISTRY_RESOURCE_TYPE), configured_default='acr', validator=validate_registry_name)
         c.argument("workflow_type", arg_type=get_enum_type(CSSCTaskTypes), options_list=['--type', '-t'], help="Type of workflow task.", required=True)
 

--- a/src/acrcssc/azext_acrcssc/_params.py
+++ b/src/acrcssc/azext_acrcssc/_params.py
@@ -19,7 +19,7 @@ def load_arguments(self: AzCommandsLoader, _):
     from .helper._workflow_status import WorkflowTaskState
 
     with self.argument_context("acr supply-chain workflow") as c:
-        c.argument('resource_group', resource_group_name_type, completer=get_resource_name_completion_list(REGISTRY_RESOURCE_TYPE))
+        c.argument('resource_group', arg_type=resource_group_name_type, completer=get_resource_name_completion_list(REGISTRY_RESOURCE_TYPE))
         c.argument('registry_name', options_list=['--registry', '-r'], help='The name of the container registry. It should be specified in lower case. You can configure the default registry name using `az configure --defaults acr=<registry name>`', completer=get_resource_name_completion_list(REGISTRY_RESOURCE_TYPE), configured_default='acr', validator=validate_registry_name)
         c.argument("workflow_type", arg_type=get_enum_type(CSSCTaskTypes), options_list=['--type', '-t'], help="Type of workflow task.", required=True)
 


### PR DESCRIPTION
- Fix versioning used in HISTORY to reflect final version used in preview (1.0.0b1)
- change resource group parameter to use resource_group_name_type from azure.cli.core.commands.parameters