### PR TITLE
update cache rule create and update commands to filter for exact tag

### DIFF
--- a/src/acrcache/HISTORY.rst
+++ b/src/acrcache/HISTORY.rst
@@ -2,6 +2,11 @@
 
 Release History
 ===============
+1.0.0c9
+++++++  
+* **FEATURE**: added new artifact sync filtering options for cache rules
+  * `--tag`: filter tag by exact name
+
 1.0.0c8
 ++++++
 * **BUGFIX**: Resolved issue with sync-referrers enabled without `--sync activesync`

--- a/src/acrcache/HISTORY.rst
+++ b/src/acrcache/HISTORY.rst
@@ -6,6 +6,7 @@ Release History
 ++++++  
 * **FEATURE**: added new artifact sync filtering options for cache rules
   * `--tag`: filter tag by exact name
+* **ENHANCEMENT**:Improved error messages for invalid parameter combinations  
 
 1.0.0c8
 ++++++

--- a/src/acrcache/README.rst
+++ b/src/acrcache/README.rst
@@ -27,6 +27,13 @@ The `acrcache` extension adds support for managing Azure Container Registry (ACR
   - **--include-image-types**: Specify image types to include in sync.
   - **--exclude-image-types**: Specify image types to exclude from sync.
 
+- **Tag filtering options** (mutually exclusive):
+
+  - **--tag**: Specify an exact tag name to sync.
+  - **--starts-with**: Sync tags that start with a specific prefix.
+  - **--ends-with**: Sync tags that end with a specific suffix.
+  - **--contains**: Sync tags that contain a specific substring.
+
 Installation
 ==============
 
@@ -34,7 +41,7 @@ Installation
 
 1. Install Python (minimum supported version is 3.6; Python 3.12 is recommended) from http://python.org.
 
-2. Fork and clone the required repo's
+2. Fork and clone the required repos
     - Azure CLI Repo : https://github.com/Azure/azure-cli  
     - Azure CLI Extensions Repo : https://github.com/AzureCR/azure-cli-extensions. 
 
@@ -91,7 +98,7 @@ Installation
         Due to a known issue, the Azure CLI currently requires an older version of setuptools (70.0.0) and wheel (0.30.0) because newer versions are incompatible and may cause installation or build                    failures.         
         For more details, see the related issue: https://github.com/Azure/azure-cli/issues/29467
 
-      - pip install setuptools==70.0.0 	
+      - pip install setuptools==70.0.0
 
       - pip install --force-reinstall wheel==0.30.0
 
@@ -119,22 +126,22 @@ If you make changes to the extension, you can test it by running:
 
   **this will build your new changes into the extension package which you will see immediately.**
 
-After building the extension, if you dont see your changes immediately outputed in the cli, you can run the following command to reinstall the newly built extension:
+After building the extension, if you don't see your changes immediately outputted in the CLI, you can run the following command to reinstall the newly built extension:
 
     - az extension remove --name acrcache
-    - az extension add --source "path\dist\acrcache-1.0.<0rc8>-py3-none-any.whl" 
+    - az extension add --source "path\dist\acrcache.whl" 
 
 
 **Usage**
 ==============
 
-**cache rules Create, update, list, show, and sync **
+**Cache Rules: create, update, list, show, and sync**
 
     see `az acr cache -h` for more information and examples.
 
 **Authentication Methods**
 
-  ** User-Assigned Managed Identity**
+  **User-Assigned Managed Identity**
 
     The `--assign-identity` parameter enables secure authentication between Azure Container Registries using user-assigned managed identities. This is particularly useful for:
 
@@ -148,7 +155,7 @@ After building the extension, if you dont see your changes immediately outputed 
       --assign-identity /subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<identity-name>
     ```  
 
-  ** Credentials**
+  **Credentials**
 
     If `--assign-identity` is not specified in a cache rule command, the extension will fall back to using existing credentials configured for the target registry. This may include:
 
@@ -160,19 +167,20 @@ After building the extension, if you dont see your changes immediately outputed 
         az acr cache create -r <target-registry> -n <rule-name> -s <source-registry>.azurecr.io/<repo> -t <target-repo> --credential-set
     ```
 
-** Important Notes**
+**Important Notes**
 ==============
 
-  ** Sync Modes **
+  **Sync Modes**
     - **PassiveSync** (default): Pull-through cache behavior - images are cached when pulled
     - **ActiveSync**: Proactive synchronization - images are automatically pulled and cached
   
-  ** Parameter Dependencies **
+  **Parameter Dependencies**
     - --sync-referrers enabled requires **--sync activesync**
     -  Artifact filtering parameters (--platforms, --include-artifact-types, etc.) require **--sync activesync**
-    -  Tag filters (--starts-with, --ends-with, --contains) require **--sync activesync**
+    -  Tag filtering parameters (--tag, --starts-with, --ends-with, --contains) require **--sync activesync**
+    -  Tag filtering options are mutually exclusive: use either **--tag** for exact match OR pattern-based filters (--starts-with, --ends-with, --contains)
 
-** Minimum Azure CLI Version **
+**Minimum Azure CLI Version**
 ==============
 
   This extension requires Azure CLI version **2.57.0** or higher.

--- a/src/acrcache/azext_acrcache/_help.py
+++ b/src/acrcache/azext_acrcache/_help.py
@@ -50,6 +50,8 @@ examples:
     text: az acr cache create -r myregistry -n MyRule -s upstreamacrregistry.azurecr-test.io -t acr-to-acr-cacherule --assign-identity /subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identity-name}
   - name: Create a cache rule with artifact sync enabled and set a tag filter.
     text: az acr cache create -r myregistry -n MyRule -s docker.io/library/ubuntu -t ubuntu --sync activesync --starts-with v1 --ends-with beta
+  - name: Create a cache rule with artifact sync enabled and sync only a specific tag.
+    text: az acr cache create -r myregistry -n MyRule -s docker.io/library/nginx -t library/nginx --sync activesync --tag 8.0
   - name: Create a cache rule with artifact sync enabled, set a tag filter, and specify platforms and sync referrers.
     text: az acr cache create -r myregistry -n MyRule -s docker.io/library/ubuntu -t ubuntu --sync activesync --starts-with v1 --ends-with beta --platforms linux/amd64,linux/arm64 --sync-referrers enabled
   - name: Create a cache rule with artifact sync enabled, set a tag filter, and specify  platforms, sync referrers and artifact types to include.
@@ -88,6 +90,8 @@ examples:
     text: az acr cache update -r myregistry -n MyRule --sync activesync --starts-with v1 --ends-with beta --platforms linux/amd64,linux/arm64 --sync-referrers enabled
   - name: Enable artifact sync, set a tag filter, and specify platforms, sync referrers and artifact types to include.
     text: az acr cache update -r myregistry -n MyRule --sync activesync --starts-with v1 --ends-with beta --platforms linux/amd64,linux/arm64 --sync-referrers enabled --include-artifact-types images,notary-project-signature
+  - name: Update cache rule to sync only a specific tag.
+    text: az acr cache update -r myregistry -n MyRule --sync activesync --tag latest
   - name: Enable artifact sync, set a tag filter, and specify platforms, sync referrers and artifact types to exclude.
     text: az acr cache update -r myregistry -n MyRule --sync activesync --starts-with v1 --ends-with beta --platforms linux/amd64,linux/arm64 --sync-referrers enabled --exclude-artifact-types application/vnd.aquasec.trivy.vulnerability.report
 """

--- a/src/acrcache/azext_acrcache/_params.py
+++ b/src/acrcache/azext_acrcache/_params.py
@@ -22,6 +22,7 @@ def load_arguments(self, _):
         c.argument('starts_with', help='Only sync the tags that start with the specified string.')
         c.argument('ends_with', help='Only sync the tags that end with the specified string.')
         c.argument('contains', help='Only sync the tags that contain the specified string.')
+        c.argument('tag', help='Only sync the artifacts with this exact tag name. This is an exact match filter.')
         c.argument('image', help='The name of the tag you want to sync immediately. Can only be used if artifact sync is enabled and the tag is within any specified tag filter.')
         c.argument('platforms', help='A list of platforms to filter the artifacts by. e.g. amd64/linux')
         c.argument('sync_referrers', arg_type=get_enum_type(['Enabled', 'Disabled']), help='Enable or disable syncing the referrers of the artifacts. Default is Disabled.')

--- a/src/acrcache/azext_acrcache/cache.py
+++ b/src/acrcache/azext_acrcache/cache.py
@@ -345,7 +345,7 @@ def acr_cache_update_custom(cmd,
     updated_image_types = None
 
     #preserve old artifact sync filters
-    preserve_filters = (properties.artifact_sync_filters is not None and isActiveSync)
+    preserve_filters = (properties.artifact_sync_filters is not None and is_active_sync)
 
     if preserve_filters:
         # Copy tag filters If no new filters are provided
@@ -386,7 +386,7 @@ def acr_cache_update_custom(cmd,
 
     #update artifact sync filters object
     updated_artifact_sync_filters = None
-    if isActiveSync:
+    if is_active_sync:
         if starts_with or ends_with or contains or tag:
             updated_tags = TagFilter(
                 type="KQL",
@@ -442,7 +442,7 @@ def acr_cache_update_custom(cmd,
         artifact_sync_filters=updated_artifact_sync_filters
     )
 
-    if isActiveSync:
+    if is_active_sync:
         user_confirmation("Your cache rule has Artifact Sync enabled and will automatically import tags into your registry. This may incur additional storage charges. Continue?", yes)
 
     if remove_cred_set:

--- a/src/acrcache/azext_acrcache/cache.py
+++ b/src/acrcache/azext_acrcache/cache.py
@@ -173,7 +173,7 @@ def acr_cache_create(cmd,
         rg = resource_group_name
     else:
         #extract resource group from registry id
-        import re
+
         match = re.search(r'/resourceGroups/([^/]+)/', registry.id)
         rg = match.group(1) if match else None
 
@@ -206,8 +206,9 @@ def acr_cache_create(cmd,
 
     identity_properties = process_assign_identity_parameter(assign_identity)
 
+    # Validate that source_repo doesn't contain tags. Users must use --tag parameter
     if ':' in source_repo:
-        source_repo, source_tag = source_repo.rsplit(':', 1)
+        raise CLIError("Source repository should not include a tag. Please use the --tag parameter to specify tag for filtering.")
 
     #create artifact sync filters object
     artifact_sync_filters = None
@@ -325,10 +326,10 @@ def acr_cache_update_custom(cmd,
 
     #check if activesync is enabled 
     #check both existing sync mode (when not changing sync) AND new sync value (when updating sync)
-    isActiveSync = (sync is None and sync_mode and sync_mode.lower() == 'activesync') or (sync and sync.lower() == 'activesync')
+    is_active_sync = (sync is None and sync_mode and sync_mode.lower() == 'activesync') or (sync and sync.lower() == 'activesync')
 
     # Validate sync_referrers requires activesync
-    if sync_referrers and sync_referrers.lower() == 'enabled' and not isActiveSync:
+    if sync_referrers and sync_referrers.lower() == 'enabled' and not is_active_sync:
         raise CLIError("Syncing referrers requires sync to be set to 'activesync'. Please update your cache rule configuration.")
 
     # Warn if mutually exclusive parameters are provided

--- a/src/acrcache/azext_acrcache/cache.py
+++ b/src/acrcache/azext_acrcache/cache.py
@@ -21,23 +21,23 @@ from .vendored_sdks.containerregistry.v2025_09_01_preview.generated.container_re
 MANAGED_IDENTITY_RESOURCE_PROVIDER = "Microsoft.ManagedIdentity"
 USER_ASSIGNED_IDENTITY_RESOURCE_TYPE = "userAssignedIdentities"
 
-def _create_kql(starts_with=None, ends_with=None, contains=None):
-    if not starts_with and not ends_with and not contains:
+def _create_kql(starts_with=None, ends_with=None, contains=None, tag=None):
+    if not starts_with and not ends_with and not contains and not tag:
         return "Tags"
 
     query = "Tags | where "
+    conditions = []
 
     if starts_with:
-        query += f"Name startswith '{starts_with}'"
-        if ends_with or contains:
-            query += " and "
+        conditions.append(f"Name startswith '{starts_with}'")
     if ends_with:
-        query += f"Name endswith '{ends_with}'"
-        if contains:
-            query += " and "
+        conditions.append(f"Name endswith '{ends_with}'")
     if contains:
-        query += f"Name contains '{contains}'"
+        conditions.append(f"Name contains '{contains}'")
+    if tag:
+        conditions.append(f"Name == '{tag}'")
 
+    query += " and ".join(conditions)
     return query
 
 
@@ -45,6 +45,7 @@ def _separate_params(query):
     starts_with = None
     ends_with = None
     contains = None
+    tag = None
 
     if "Name startswith" in query:
         starts_with = query.split("Name startswith")[1].split("'")[1]
@@ -54,8 +55,11 @@ def _separate_params(query):
 
     if "Name contains" in query:
         contains = query.split("Name contains")[1].split("'")[1]
+    
+    if "Name ==" in query:
+        tag = query.split("Name ==")[1].split("'")[1]
 
-    return starts_with, ends_with, contains
+    return starts_with, ends_with, contains, tag
 
 def process_assign_identity_parameter(assign_identity: str) -> IdentityProperties:
     """Process assign identity parameter and return IdentityProperties object.
@@ -151,6 +155,7 @@ def acr_cache_create(cmd,
                      starts_with=None,
                      ends_with=None,
                      contains=None,
+                     tag=None,
                      dry_run=False,
                      yes=False,
                      platforms=None,
@@ -192,19 +197,17 @@ def acr_cache_create(cmd,
     #validate that filter parameters require sync to be enabled
     if sync and sync.lower() != 'activesync' and (include_artifact_types or exclude_artifact_types or 
                               include_image_types or exclude_image_types or 
-                              platforms or starts_with or ends_with or contains):
+                              platforms or starts_with or ends_with or contains or tag):
         raise CLIError("Artifact sync filters (--include-artifact-types, --exclude-artifact-types, "
                         "--include-image-types, --exclude-image-types, --platforms, "
-                        "--starts-with, --ends-with, --contains) require --sync activesync.")
+                        "--starts-with, --ends-with, --contains, --tag) require --sync activesync.")
 
     cred_set_id = AzureCoreNull if not cred_set else f'{registry.id}/credentialSets/{cred_set}'
 
     identity_properties = process_assign_identity_parameter(assign_identity)
 
-    tag = None
-
     if ':' in source_repo:
-        source_repo, tag = source_repo.rsplit(':', 1)
+        source_repo, source_tag = source_repo.rsplit(':', 1)
 
     #create artifact sync filters object
     artifact_sync_filters = None
@@ -245,8 +248,10 @@ def acr_cache_create(cmd,
                 values=exclude_image_list
             )
 
-        kql_str = f"Tags | where Name == '{tag}'" if tag is not None else _create_kql(starts_with, ends_with, contains)
-        if sync and not kql_str:
+        # Generate KQL query for tag filtering
+        if starts_with or ends_with or contains or tag:
+            kql_str = _create_kql(starts_with, ends_with, contains, tag)
+        else:
             kql_str = "Tags"
 
         artifact_sync_filters["tags"] = TagFilter(
@@ -273,7 +278,7 @@ def acr_cache_create(cmd,
         identity=identity_properties
     )
 
-    if tag is None and sync and not dry_run:
+    if not (starts_with or ends_with or contains or tag) and sync and not dry_run:
         user_confirmation("Your cache rule has Artifact Sync enabled and will automatically import tags into your registry. This may incur additional storage charges. Run with the dry-run flag for details. Continue?", yes)
 
     return client.begin_create(
@@ -296,6 +301,7 @@ def acr_cache_update_custom(cmd,
                             starts_with=None,
                             ends_with=None,
                             contains=None,
+                            tag=None,
                             yes=False,
                             platforms=None,
                             sync_referrers=None,
@@ -380,10 +386,10 @@ def acr_cache_update_custom(cmd,
     #update artifact sync filters object
     updated_artifact_sync_filters = None
     if isActiveSync:
-        if starts_with or ends_with or contains:
+        if starts_with or ends_with or contains or tag:
             updated_tags = TagFilter(
                 type="KQL",
-                query=_create_kql(starts_with, ends_with, contains)
+                query=_create_kql(starts_with, ends_with, contains, tag)
             )
 
         if platforms:

--- a/src/acrcache/azext_acrcache/tests/latest/test_cache.py
+++ b/src/acrcache/azext_acrcache/tests/latest/test_cache.py
@@ -22,8 +22,21 @@ class TestCacheUtilityFunctions(unittest.TestCase):
                         "Tags | where Name startswith 'foo' and Name contains 'baz'")
         self.assertEqual(cache._create_kql(ends_with="bar", contains="baz"), 
                         "Tags | where Name endswith 'bar' and Name contains 'baz'")
-        self.assertEqual(cache._create_kql(tag="exact", starts_with="foo"), 
-                        "Tags | where Name startswith 'foo' and Name == 'exact'")
+        # Test that specific tag is mutually exclusive with other filters
+        with self.assertRaises(CLIError):
+            cache._create_kql(tag="exact", starts_with="foo")
+        with self.assertRaises(CLIError):
+            cache._create_kql(tag="exact", ends_with="bar")
+        with self.assertRaises(CLIError):
+            cache._create_kql(tag="exact", contains="baz")
+        with self.assertRaises(CLIError):
+            cache._create_kql(tag="exact", starts_with="foo", ends_with="bar")
+        with self.assertRaises(CLIError):
+            cache._create_kql(tag="exact", starts_with="foo", contains="baz")
+        with self.assertRaises(CLIError):
+            cache._create_kql(tag="exact", ends_with="bar", contains="baz")
+        with self.assertRaises(CLIError):
+            cache._create_kql(tag="exact", starts_with="foo", ends_with="bar", contains="baz")
         self.assertEqual(cache._create_kql(starts_with="foo", ends_with="bar", contains="baz"), 
                         "Tags | where Name startswith 'foo' and Name endswith 'bar' and Name contains 'baz'")
 

--- a/src/acrcache/azext_acrcache/tests/latest/test_cache.py
+++ b/src/acrcache/azext_acrcache/tests/latest/test_cache.py
@@ -15,22 +15,34 @@ class TestCacheUtilityFunctions(unittest.TestCase):
         self.assertEqual(cache._create_kql(starts_with="foo"), "Tags | where Name startswith 'foo'")
         self.assertEqual(cache._create_kql(ends_with="bar"), "Tags | where Name endswith 'bar'")
         self.assertEqual(cache._create_kql(contains="baz"), "Tags | where Name contains 'baz'")
+        self.assertEqual(cache._create_kql(tag="exact"), "Tags | where Name == 'exact'")
         self.assertEqual(cache._create_kql(starts_with="foo", ends_with="bar"), 
                         "Tags | where Name startswith 'foo' and Name endswith 'bar'")
         self.assertEqual(cache._create_kql(starts_with="foo", contains="baz"), 
                         "Tags | where Name startswith 'foo' and Name contains 'baz'")
         self.assertEqual(cache._create_kql(ends_with="bar", contains="baz"), 
                         "Tags | where Name endswith 'bar' and Name contains 'baz'")
+        self.assertEqual(cache._create_kql(tag="exact", starts_with="foo"), 
+                        "Tags | where Name startswith 'foo' and Name == 'exact'")
         self.assertEqual(cache._create_kql(starts_with="foo", ends_with="bar", contains="baz"), 
                         "Tags | where Name startswith 'foo' and Name endswith 'bar' and Name contains 'baz'")
 
     def test_separate_params(self):
         """Test parameter extraction from KQL queries"""
         q = "Tags | where Name startswith 'foo' and Name endswith 'bar' and Name contains 'baz'"
-        starts_with, ends_with, contains = cache._separate_params(q)
+        starts_with, ends_with, contains, tag = cache._separate_params(q)
         self.assertEqual(starts_with, "foo")
         self.assertEqual(ends_with, "bar")
         self.assertEqual(contains, "baz")
+        self.assertIsNone(tag)
+        
+        # Test exact tag match
+        q_tag = "Tags | where Name == 'exact'"
+        starts_with, ends_with, contains, tag = cache._separate_params(q_tag)
+        self.assertIsNone(starts_with)
+        self.assertIsNone(ends_with)
+        self.assertIsNone(contains)
+        self.assertEqual(tag, "exact")
 
 
 class TestCacheOperations(unittest.TestCase):

--- a/src/acrcache/setup.py
+++ b/src/acrcache/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
 # HISTORY.rst entry.
-VERSION = '1.0.0c8' 
+VERSION = '1.0.0c9' 
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Added --tag argument to cache rule create/update commands for exact tag match filtering (_params.py, _help.py).

Modified KQL query builder and its parameter extraction function to handle the new tag filter.

Updated logic in acr_cache_create and acr_cache_update_custom to incorporate the --tag option in artifact sync filters.

Extended unit tests in test_cache.py to cover exact tag filtering.

Bumped extension version to 1.0.0c9 and updated HISTORY.rst.

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
